### PR TITLE
OpenAPI 定義作成 #15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: openapi-lint openapi-ui
+
+openapi-lint:
+	docker run --rm -v "$(PWD):/work" -w /work node:20 \
+	  sh -lc "npx -y @redocly/cli lint --config openapi/.redocly.yaml openapi/openapi.yaml"
+
+openapi-ui:
+	docker run --rm -p 8081:8080 \
+	  -e SWAGGER_JSON=/openapi/openapi.yaml \
+	  -v "$(PWD)/openapi:/openapi" \
+	  swaggerapi/swagger-ui

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -58,6 +58,12 @@ group :development, :test do
   gem "factory_bot_rails"
 end
 
+group :test do
+  gem "committee"
+  gem "committee-rails"
+end
+
+
 
 gem "jwt"
 gem "rack-cors"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -87,6 +87,15 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    committee (5.6.1)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (~> 2.0)
+      rack (>= 1.5)
+    committee-rails (0.10.0)
+      actionpack (>= 6.0)
+      activesupport (>= 6.0)
+      committee (>= 5.1.0)
+      railties (>= 6.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -129,6 +138,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.0)
+    json_schema (0.21.0)
     jwt (3.1.2)
       base64
     kamal (2.10.1)
@@ -190,6 +200,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-musl)
       racc (~> 1.4)
+    openapi_parser (2.3.1)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -362,6 +373,8 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundler-audit
+  committee
+  committee-rails
   debug
   factory_bot_rails
   image_processing (~> 1.2)

--- a/backend/app/controllers/api/v1/me_controller.rb
+++ b/backend/app/controllers/api/v1/me_controller.rb
@@ -6,7 +6,7 @@ module Api
       include ClerkAuthenticatable
 
       def show
-        render json: { id: current_user.id, external_uid: current_user.external_uid }
+        render json: { user: current_user.as_json(only: %i[id external_uid name email notify_email theme_mode created_at updated_at]) }
       end
     end
   end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require_relative "../config/environment"
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 
 require "rspec/rails"
+require "committee/rails/test/methods"
+
 
 # ✅ spec/support 配下のヘルパーや shared_context を自動で読み込む
 Rails.root.glob("spec/support/**/*.rb").sort_by(&:to_s).each { |f| require f }
@@ -36,4 +38,6 @@ RSpec.configure do |config|
   config.before(:each, type: :request) do
     host! "localhost"
   end
+
+  config.include Committee::Rails::Test::Methods, type: :request
 end

--- a/backend/spec/requests/api/v1/me_spec.rb
+++ b/backend/spec/requests/api/v1/me_spec.rb
@@ -39,12 +39,13 @@ RSpec.describe "GET /api/v1/me", type: :request do
             allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
           end
 
-          it "重複作成せず 200 を返す" do
+          it "重複作成せず 200 を返し、OpenAPI schema に一致する" do
             expect { do_request }.not_to change(User, :count)
 
             expect(response).to have_http_status(:ok)
             expect(User.where(external_uid: sub).count).to eq(1)
             expect(User.find_by!(external_uid: sub).id).to eq(existing_user.id)
+            assert_response_schema_confirm
           end
         end
       end

--- a/backend/spec/support/committee.rb
+++ b/backend/spec/support/committee.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "committee"
+
+RSpec.configure do |config|
+  config.add_setting :committee_options, default: {
+    schema_path: ENV.fetch(
+      "OPENAPI_SCHEMA_PATH",
+      Rails.root.join("../openapi/openapi.yaml").to_s
+    ),
+    parse_response_by_content_type: false,
+    strict: true
+  }
+
+  config.define_derived_metadata(file_path: %r{/spec/requests/}) do |metadata|
+    metadata[:committee] = true
+  end
+
+  config.before(:each, committee: true) do
+    schema_path = RSpec.configuration.committee_options[:schema_path]
+    @committee_schema = Committee::Drivers::OpenAPI3::Driver.new.parse(File.read(schema_path))
+  end
+end

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,7 @@ services:
     env_file:
       - ./backend/.env
     environment:
+      OPENAPI_SCHEMA_PATH: /openapi/openapi.yaml
       TZ: UTC
       RAILS_ENV: development
       DATABASE_HOST: db
@@ -40,6 +41,7 @@ services:
       - "3000:3000"
     volumes:
       - ./backend:/app
+      - ./openapi:/openapi:ro
       - bundle-cache:/usr/local/bundle
     tty: true
     stdin_open: true
@@ -63,10 +65,22 @@ services:
       - "8000:3000"
     volumes:
       - ./frontend:/app
+      - ./openapi:/openapi:ro
       - node-modules:/app/node_modules
     depends_on:
       - api
     command: bash -lc "npm install && npm run dev -- -p 3000 -H 0.0.0.0"
+
+  swagger-ui:
+    image: swaggerapi/swagger-ui:latest
+    environment:
+      SWAGGER_JSON: /openapi/openapi.yaml
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./openapi:/openapi:ro
+    depends_on:
+      - api
 
 volumes:
   db-data:

--- a/openapi/.redocly.yaml
+++ b/openapi/.redocly.yaml
@@ -1,0 +1,5 @@
+extends:
+  - recommended
+
+rules:
+  no-server-example.com: off

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,1170 @@
+openapi: 3.0.3
+info:
+  title: Splitto API
+  version: 0.1.0
+  description: >
+    Splitto（割り勘・立替精算）API仕様（MVP）
+  license:
+    name: UNLICENSED
+
+servers:
+  - url: https://api.splitto.example.com
+    description: Production (placeholder)
+  - url: http://localhost:3000
+    description: Rails API (local)
+
+tags:
+  - name: Auth
+    description: 認証・ログインユーザー関連
+  - name: Users
+    description: ユーザー情報
+  - name: Groups
+    description: グループ管理
+  - name: Members
+    description: グループメンバー管理
+  - name: Expenses
+    description: 支払い（立替）管理
+  - name: Attachments
+    description: 添付ファイル
+  - name: Audits
+    description: 監査ログ
+  - name: MailLogs
+    description: メール送信履歴
+
+security:
+  - BearerAuth: []
+
+paths:
+  /api/v1/me:
+    get:
+      operationId: getMe
+      tags:
+        - Auth
+      summary: ログインユーザー情報の取得
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v1/users/{userId}:
+    get:
+      operationId: getUserById
+      tags:
+        - Users
+      summary: ユーザー取得（ID）
+      parameters:
+        - $ref: "#/components/parameters/UserId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups:
+    get:
+      operationId: listGroups
+      tags:
+        - Groups
+      summary: グループ一覧
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      operationId: createGroup
+      tags:
+        - Groups
+      summary: グループ作成
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v1/groups/{groupId}:
+    get:
+      operationId: getGroup
+      tags:
+        - Groups
+      summary: グループ詳細
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      operationId: updateGroup
+      tags:
+        - Groups
+      summary: グループ更新
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupUpdateRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/members:
+    get:
+      operationId: listMembers
+      tags:
+        - Members
+      summary: メンバー一覧
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - name: active
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: true=在籍中のみ / false=退出済みのみ / 未指定=全件
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    post:
+      operationId: addMember
+      tags:
+        - Members
+      summary: メンバー追加（招待/参加）
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAddRequest"
+      responses:
+        "201":
+          description: Created / Re-joined
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /api/v1/groups/{groupId}/members/{memberId}/leave:
+    post:
+      operationId: leaveMember
+      tags:
+        - Members
+      summary: 退出（active=false, left_at=now）
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/MemberId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MemberResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/expenses:
+    get:
+      operationId: listExpenses
+      tags:
+        - Expenses
+      summary: 支払い一覧
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
+        - name: paid_on_from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: paid_on_to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: paid_by_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: include_deleted
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExpenseListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    post:
+      operationId: createExpense
+      tags:
+        - Expenses
+      summary: 支払い作成（splitsを確定保存）
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExpenseCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExpenseResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/expenses/{expenseId}:
+    get:
+      operationId: getExpense
+      tags:
+        - Expenses
+      summary: 支払い詳細
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/ExpenseId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExpenseResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      operationId: updateExpense
+      tags:
+        - Expenses
+      summary: 支払い更新（MVP）
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/ExpenseId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExpenseUpdateRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExpenseResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteExpense
+      tags:
+        - Expenses
+      summary: 支払い削除（論理削除）
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/ExpenseId"
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/expenses/{expenseId}/attachments:
+    post:
+      operationId: createAttachment
+      tags:
+        - Attachments
+      summary: 添付ファイルメタ情報の登録
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/ExpenseId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AttachmentCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AttachmentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/audits:
+    get:
+      operationId: listAudits
+      tags:
+        - Audits
+      summary: 監査ログ一覧
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/groups/{groupId}/mail_logs:
+    get:
+      operationId: listMailLogs
+      tags:
+        - MailLogs
+      summary: メール送信履歴一覧
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/MailLogStatus"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MailLogListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    Page:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+
+    PerPage:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+
+    UserId:
+      name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+    GroupId:
+      name: groupId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+    MemberId:
+      name: memberId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+    ExpenseId:
+      name: expenseId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+    Conflict:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              example: bad_request
+            message:
+              type: string
+              example: invalid parameter
+            details:
+              type: array
+              items:
+                type: string
+
+    ThemeMode:
+      type: string
+      enum:
+        - SYSTEM
+        - LIGHT
+        - DARK
+
+    MemberRole:
+      type: string
+      enum:
+        - OWNER
+        - MEMBER
+
+    SplitType:
+      type: string
+      enum:
+        - EQUAL_ALL
+        - EQUAL_SELECTED
+        - AMOUNT
+        - PERCENT
+
+    MailLogStatus:
+      type: string
+      enum:
+        - QUEUED
+        - SENT
+        - FAILED
+    User:
+      type: object
+      required:
+        - id
+        - external_uid
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: integer
+          format: int64
+        external_uid:
+          type: string
+
+        # /me で「未設定のまま返る」可能性があるので nullable にする
+        name:
+          type: string
+          nullable: true
+
+        email:
+          type: string
+          nullable: true
+
+        # 未設定のまま返る可能性があるなら nullable: true にする
+        notify_email:
+          type: boolean
+          nullable: true
+          default: true
+
+        # $ref のままだと nullable を直接付けられないので allOf で包む
+        theme_mode:
+          allOf:
+            - $ref: "#/components/schemas/ThemeMode"
+          nullable: true
+
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    UserResponse:
+      type: object
+      required:
+        - user
+      properties:
+        user:
+          $ref: "#/components/schemas/User"
+
+    Group:
+      type: object
+      required:
+        - id
+        - name
+        - owner_id
+        - currency
+        - invite_token
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        owner_id:
+          type: string
+          format: uuid
+        currency:
+          type: string
+          example: JPY
+        invite_token:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    GroupCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        currency:
+          type: string
+          example: JPY
+
+    GroupUpdateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        currency:
+          type: string
+
+    GroupResponse:
+      type: object
+      required:
+        - group
+      properties:
+        group:
+          $ref: "#/components/schemas/Group"
+
+    GroupListResponse:
+      type: object
+      required:
+        - groups
+        - meta
+      properties:
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/Group"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    Member:
+      type: object
+      required:
+        - id
+        - group_id
+        - user_id
+        - role
+        - active
+        - joined_at
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        group_id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+          format: uuid
+        role:
+          $ref: "#/components/schemas/MemberRole"
+        active:
+          type: boolean
+          default: true
+        joined_at:
+          type: string
+          format: date-time
+        left_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    MemberAddRequest:
+      type: object
+      required:
+        - user_id
+      properties:
+        user_id:
+          type: string
+          format: uuid
+        role:
+          $ref: "#/components/schemas/MemberRole"
+
+    MemberResponse:
+      type: object
+      required:
+        - member
+      properties:
+        member:
+          $ref: "#/components/schemas/Member"
+
+    MemberListResponse:
+      type: object
+      required:
+        - members
+      properties:
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/Member"
+
+    Expense:
+      type: object
+      required:
+        - id
+        - group_id
+        - paid_by_id
+        - created_by_id
+        - amount_cents
+        - paid_on
+        - split_type
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        group_id:
+          type: string
+          format: uuid
+        paid_by_id:
+          type: string
+          format: uuid
+        created_by_id:
+          type: string
+          format: uuid
+        amount_cents:
+          type: integer
+          minimum: 1
+        paid_on:
+          type: string
+          format: date
+        category:
+          type: string
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        split_type:
+          $ref: "#/components/schemas/SplitType"
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Split:
+      type: object
+      required:
+        - id
+        - expense_id
+        - user_id
+        - share_cents
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        expense_id:
+          type: string
+          format: uuid
+        user_id:
+          type: string
+          format: uuid
+        share_cents:
+          type: integer
+          minimum: 0
+        share_percent:
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 100
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SplitCreateItem:
+      type: object
+      required:
+        - user_id
+        - share_cents
+      properties:
+        user_id:
+          type: string
+          format: uuid
+        share_cents:
+          type: integer
+          minimum: 0
+        share_percent:
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 100
+
+    ExpenseCreateRequest:
+      type: object
+      required:
+        - paid_by_id
+        - created_by_id
+        - amount_cents
+        - paid_on
+        - split_type
+        - splits
+      properties:
+        paid_by_id:
+          type: string
+          format: uuid
+        created_by_id:
+          type: string
+          format: uuid
+        amount_cents:
+          type: integer
+          minimum: 1
+        paid_on:
+          type: string
+          format: date
+        category:
+          type: string
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        split_type:
+          $ref: "#/components/schemas/SplitType"
+        splits:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/SplitCreateItem"
+
+    ExpenseUpdateRequest:
+      type: object
+      properties:
+        paid_on:
+          type: string
+          format: date
+        category:
+          type: string
+          nullable: true
+        note:
+          type: string
+          nullable: true
+
+    ExpenseResponse:
+      type: object
+      required:
+        - expense
+        - splits
+        - attachments
+      properties:
+        expense:
+          $ref: "#/components/schemas/Expense"
+        splits:
+          type: array
+          items:
+            $ref: "#/components/schemas/Split"
+        attachments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Attachment"
+
+    ExpenseListResponse:
+      type: object
+      required:
+        - expenses
+        - meta
+      properties:
+        expenses:
+          type: array
+          items:
+            $ref: "#/components/schemas/Expense"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    Attachment:
+      type: object
+      required:
+        - id
+        - expense_id
+        - file_key
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        expense_id:
+          type: string
+          format: uuid
+        file_key:
+          type: string
+        content_type:
+          type: string
+          nullable: true
+        byte_size:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    AttachmentCreateRequest:
+      type: object
+      required:
+        - file_key
+      properties:
+        file_key:
+          type: string
+        content_type:
+          type: string
+          nullable: true
+        byte_size:
+          type: integer
+          nullable: true
+
+    AttachmentResponse:
+      type: object
+      required:
+        - attachment
+      properties:
+        attachment:
+          $ref: "#/components/schemas/Attachment"
+
+    Audit:
+      type: object
+      required:
+        - id
+        - actor_id
+        - action
+        - target_type
+        - target_id
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        group_id:
+          type: string
+          format: uuid
+          nullable: true
+        actor_id:
+          type: string
+          format: uuid
+        action:
+          type: string
+          example: expense.created
+        target_type:
+          type: string
+          example: Expense
+        target_id:
+          type: string
+          format: uuid
+        diff_json:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    AuditListResponse:
+      type: object
+      required:
+        - audits
+        - meta
+      properties:
+        audits:
+          type: array
+          items:
+            $ref: "#/components/schemas/Audit"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    MailLog:
+      type: object
+      required:
+        - id
+        - group_id
+        - from_id
+        - to_id
+        - amount_cents
+        - status
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        group_id:
+          type: string
+          format: uuid
+        from_id:
+          type: string
+          format: uuid
+        to_id:
+          type: string
+          format: uuid
+        expense_id:
+          type: string
+          format: uuid
+          nullable: true
+        amount_cents:
+          type: integer
+          minimum: 0
+        status:
+          $ref: "#/components/schemas/MailLogStatus"
+        error_message:
+          type: string
+          nullable: true
+        sent_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+
+    MailLogListResponse:
+      type: object
+      required:
+        - mail_logs
+        - meta
+      properties:
+        mail_logs:
+          type: array
+          items:
+            $ref: "#/components/schemas/MailLog"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    PaginationMeta:
+      type: object
+      required:
+        - page
+        - per_page
+      properties:
+        page:
+          type: integer
+        per_page:
+          type: integer
+        total_count:
+          type: integer
+          nullable: true
+        total_pages:
+          type: integer
+          nullable: true


### PR DESCRIPTION
### 目的
バックエンド実装に入る前に、API のリクエスト・レスポンス形式を明確にし、  
フロントエンドとバックエンドが並列で開発できる状態を作るため、  
OpenAPI（Swagger）で API 仕様を定義する。

---

### 対応内容
- root ディレクトリ配下に `openapi/` ディレクトリを作成
- 実装予定の API について、以下を OpenAPI 形式で定義
  - エンドポイント
  - リクエストボディ
  - クエリパラメータ
  - レスポンス形式（成功時・エラー時）
  - ステータスコード
- Swagger UI を追加し、UI 上で API 仕様を確認できる状態を整備
- `GET /api/v1/me` について
  - OpenAPI 定義に合わせてレスポンス形式を修正
  - Committee を導入し、request spec で OpenAPI schema 検証を追加

---

### 背景
実務では REST API が採用されるケースが非常に多く、その多くが OpenAPI（Swagger）で仕様管理されています。  
この形式で API 仕様を定義することで、以下のメリットがあります。

- フロントエンド・バックエンド間の仕様合意が容易になる
- API 仕様が可視化され、レビューしやすくなる
- 将来的にコード自動生成などにも活用可能

---

### 完了条件
- `openapi/` ディレクトリが作成されている
- 実装対象 API のリクエスト・レスポンス仕様が OpenAPI 形式で定義されている
- Swagger UI 上で API 仕様を確認できる状態になっている

---

### 補足
- OpenAPI 定義は MVP 想定のため、今後の実装に合わせて拡張予定
- OpenAPI からのクライアントコード生成等は今回は対応範囲外

----


### Swagger UI 確認画面
<img width="2782" height="7779" alt="screencapture-localhost-8080-2026-02-04-19_55_24" src="https://github.com/user-attachments/assets/8fe38aa8-e659-4067-ab22-571d2ccc8e21" />
