### PR TITLE
グループ作成 API（POST /api/v1/groups）を実装（作成者をOWNERでmembersに登録） #10

### DIFF
--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -1,5 +1,6 @@
-class Api::V1::GroupsController < ApplicationController
+# frozen_string_literal: true
 
+class Api::V1::GroupsController < ApplicationController
   def create
     group = nil
 
@@ -11,13 +12,18 @@ class Api::V1::GroupsController < ApplicationController
         user: current_user,
         role: "OWNER",
         active: true,
-        joined_at: Time.current
+        joined_at: Time.current,
+        left_at: nil
       )
     end
 
     render json: { group: group_json(group) }, status: :created
   rescue ActiveRecord::RecordInvalid => e
-    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+    render_validation_error(e.record)
+  rescue StandardError => e
+    Rails.logger.error("[GroupsController#create] #{e.class}: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n")) if e.backtrace.present?
+    render_internal_server_error
   end
 
   private
@@ -32,8 +38,8 @@ class Api::V1::GroupsController < ApplicationController
       name: group.name,
       currency: group.currency,
       invite_token: group.invite_token,
-      created_at: group.created_at.iso8601,
-      updated_at: group.updated_at.iso8601
+      created_at: group.created_at&.iso8601,
+      updated_at: group.updated_at&.iso8601
     }
   end
 end

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -1,0 +1,29 @@
+class Api::V1::GroupsController < ApplicationController
+  include ClerkAuthenticatable
+
+  def create
+    group = nil
+
+    ActiveRecord::Base.transaction do
+      group = Group.create!(group_params)
+
+      Member.create!(
+        group: group,
+        user: current_user,
+        role: "OWNER",
+        active: true,
+        joined_at: Time.current
+      )
+    end
+
+    render json: { group: group }, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  private
+
+  def group_params
+    params.require(:group).permit(:name, :currency)
+  end
+end

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::GroupsController < ApplicationController
-  include ClerkAuthenticatable
 
   def create
     group = nil
@@ -16,7 +15,7 @@ class Api::V1::GroupsController < ApplicationController
       )
     end
 
-    render json: { group: group }, status: :created
+    render json: { group: group_json(group) }, status: :created
   rescue ActiveRecord::RecordInvalid => e
     render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
   end
@@ -25,5 +24,16 @@ class Api::V1::GroupsController < ApplicationController
 
   def group_params
     params.require(:group).permit(:name, :currency)
+  end
+
+  def group_json(group)
+    {
+      public_id: group.public_id,
+      name: group.name,
+      currency: group.currency,
+      invite_token: group.invite_token,
+      created_at: group.created_at.iso8601,
+      updated_at: group.updated_at.iso8601
+    }
   end
 end

--- a/backend/app/controllers/api/v1/me_controller.rb
+++ b/backend/app/controllers/api/v1/me_controller.rb
@@ -1,28 +1,25 @@
 # frozen_string_literal: true
 
-module Api
-  module V1
-    class MeController < ApplicationController
-      def show
-        user = current_user
+class Api::V1::MeController < ApplicationController
+  def show
+    user = current_user
 
-        render json: { user: user_json(user) }, status: :ok
-      end
+    render json: { user: user_json(user) }, status: :ok
+  end
 
-      private
+  private
 
-      def user_json(user)
-        {
-          id: user.id,
-          external_uid: user.external_uid,
-          name: user.name,
-          email: user.email,
-          notify_email: user.notify_email,
-          theme_mode: user.theme_mode,
-          created_at: user.created_at&.iso8601,
-          updated_at: user.updated_at&.iso8601
-        }
-      end
-    end
+  def user_json(user)
+    {
+      id: user.id,
+      public_id: user.public_id,
+      external_uid: user.external_uid,
+      name: user.name,
+      email: user.email,
+      notify_email: user.notify_email,
+      theme_mode: user.theme_mode,
+      created_at: user.created_at&.iso8601,
+      updated_at: user.updated_at&.iso8601
+    }
   end
 end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::API
   include ClerkAuthenticatable
+  include ProblemRenderable
 
   before_action :authenticate_with_clerk!
+
+
 end

--- a/backend/app/controllers/concerns/clerk_authenticatable.rb
+++ b/backend/app/controllers/concerns/clerk_authenticatable.rb
@@ -34,21 +34,4 @@ module ClerkAuthenticatable
     return nil unless scheme&.casecmp("Bearer")&.zero?
     token.presence
   end
-
-  def render_unauthorized(reason, detail: nil, type: nil, instance: nil, **ext)
-    status = :unauthorized
-
-    problem = {
-      type: type || "about:blank",
-      title: "Unauthorized",
-      status: Rack::Utils.status_code(status),
-      detail: detail || "Authentication failed",
-      reason: reason,
-      **ext
-    }
-    problem[:instance] = instance if instance.present?
-
-    render json: problem, status: status, content_type: "application/problem+json"
-  end
-
 end

--- a/backend/app/controllers/concerns/problem_renderable.rb
+++ b/backend/app/controllers/concerns/problem_renderable.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ProblemRenderable
+  extend ActiveSupport::Concern
+
+  PROBLEM_JSON = "application/problem+json"
+
+  private
+
+  # RFC9457 (Problem Details)
+  #
+  # NOTE:
+  # - OpenAPI で detail が required の想定なので常に string を返す
+  # - status は integer を想定（Symbol を渡さない）
+  def render_problem(title:, status:, reason:, errors: nil, detail: nil, type: "about:blank", instance: nil, **ext)
+    payload = {
+      type: type,
+      title: title,
+      status: status,
+      reason: reason,
+      detail: detail.to_s
+    }
+
+    payload[:instance] = instance if instance.present?
+    payload[:errors] = errors if errors.present?
+    payload.merge!(ext) if ext.present?
+
+    render json: payload, status: status, content_type: PROBLEM_JSON
+  end
+
+  # 401 の detail を reason から解決して埋める（spec の期待に合わせる）
+  def render_unauthorized(reason, detail: nil, type: "about:blank", instance: nil, **ext)
+    resolved_detail =
+      detail.presence ||
+      case reason
+      when "missing_token"
+        "Authorization header is missing or invalid"
+      when "invalid_token"
+        "Token verification failed"
+      when "user_sync_failed"
+        "User synchronization failed"
+      else
+        "Authentication failed"
+      end
+
+    render_problem(
+      title: "Unauthorized",
+      status: 401,
+      reason: reason,
+      detail: resolved_detail,
+      type: type,
+      instance: instance,
+      **ext
+    )
+  end
+
+  def render_validation_error(record, reason: "validation_error", detail: nil)
+    render_problem(
+      title: "Unprocessable Entity",
+      status: 422,
+      reason: reason,
+      detail: detail,
+      errors: record.errors.messages
+    )
+  end
+
+  def render_internal_server_error(reason: "internal_server_error", detail: nil)
+    render_problem(
+      title: "Internal Server Error",
+      status: 500,
+      reason: reason,
+      detail: detail
+    )
+  end
+end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,9 +1,33 @@
+# app/models/group.rb
 class Group < ApplicationRecord
   has_many :members, inverse_of: :group, dependent: :destroy
   has_many :users, through: :members
+
+  before_validation :ensure_public_id, on: :create
+  before_validation :ensure_invite_token, on: :create
 
   validates :public_id, presence: true, uniqueness: true, length: { is: 26 }
   validates :name, presence: true
   validates :currency, presence: true
   validates :invite_token, presence: true, uniqueness: true
+
+  private
+
+  def ensure_public_id
+    return if public_id.present?
+
+    self.public_id = loop do
+      candidate = SecureRandom.base58(26)
+      break candidate unless self.class.exists?(public_id: candidate)
+    end
+  end
+
+  def ensure_invite_token
+    return if invite_token.present?
+
+    self.invite_token = loop do
+      candidate = SecureRandom.base58(32)
+      break candidate unless self.class.exists?(invite_token: candidate)
+    end
+  end
 end

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -4,8 +4,16 @@ class Member < ApplicationRecord
 
   ROLES = %w[OWNER MEMBER].freeze
 
+  before_validation :ensure_joined_at, on: :create
+
   validates :role, presence: true, inclusion: { in: ROLES }
   validates :active, inclusion: { in: [true, false] }
   validates :joined_at, presence: true
   validates :user_id, uniqueness: { scope: :group_id }
+
+  private
+
+  def ensure_joined_at
+    self.joined_at ||= Time.current
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "me", to: "me#show"
+      post "groups", to: "groups#create"
     end
   end
 end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Group, type: :model do
   describe "バリデーション" do
     context "必須属性が揃っているとき" do
-      let(:group) { build(:group) }
+      let!(:group) { build(:group) }
 
       it "有効であること" do
         expect(group).to be_valid
@@ -11,33 +13,42 @@ RSpec.describe Group, type: :model do
     end
 
     context "name がないとき" do
-      let(:group) { build(:group, name: nil) }
+      let!(:group) { build(:group, name: nil) }
+
+      before do
+        group.valid?
+      end
 
       it "無効であること" do
         expect(group).not_to be_valid
+      end
 
-        group.valid?
+      it "name のエラーが入っていること" do
         expect(group.errors[:name]).to be_present
       end
     end
   end
 
   describe "関連" do
-    it "members を持つこと" do
-      assoc = described_class.reflect_on_association(:members)
+    context "members" do
+      let!(:assoc) { described_class.reflect_on_association(:members) }
 
-      expect(assoc).to be_present
-      expect(assoc.macro).to eq(:has_many)
-      expect(assoc.class_name).to eq("Member")
+      it "members を持つこと" do
+        expect(assoc).to be_present
+        expect(assoc.macro).to eq(:has_many)
+        expect(assoc.class_name).to eq("Member")
+      end
     end
 
-    it "users を持つこと（members 経由）" do
-      assoc = described_class.reflect_on_association(:users)
+    context "users（members 経由）" do
+      let!(:assoc) { described_class.reflect_on_association(:users) }
 
-      expect(assoc).to be_present
-      expect(assoc.macro).to eq(:has_many)
-      expect(assoc.options[:through]).to eq(:members)
-      expect(assoc.class_name).to eq("User")
+      it "users を持つこと（members 経由）" do
+        expect(assoc).to be_present
+        expect(assoc.macro).to eq(:has_many)
+        expect(assoc.options[:through]).to eq(:members)
+        expect(assoc.class_name).to eq("User")
+      end
     end
   end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -32,4 +32,7 @@ RSpec.configure do |config|
 
   config.include Committee::Rails::Test::Methods, type: :request
   config.include FactoryBot::Syntax::Methods
+  config.define_derived_metadata do |meta|
+		meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+	end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -32,7 +32,22 @@ RSpec.configure do |config|
 
   config.include Committee::Rails::Test::Methods, type: :request
   config.include FactoryBot::Syntax::Methods
+
+  # request spec は aggregate_failures をデフォルトON（Splittoルール）
   config.define_derived_metadata do |meta|
-		meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
-	end
+    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+  end
+
+  # OpenAPI schema を使ってレスポンス検証（committee-rails）
+  config.committee_options = {
+    schema_path: ENV.fetch(
+      "OPENAPI_SCHEMA_PATH",
+      Rails.root.join("openapi/openapi.yaml").to_s
+    ),
+    prefix: "",
+    parse_response_by_content_type: false,
+    strict: true,
+    old_assert_behavior: false,
+    raise: true
+  }
 end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/groups", type: :request do
+  subject(:do_request) { post "/api/v1/groups", params: params, headers: headers, as: :json }
+
+  describe "認証" do
+    context "Authorization が Bearer 形式で、verify! が成功するとき" do
+      let(:token) { "dummy" }
+      let(:headers) do
+        {
+          "Authorization" => "Bearer #{token}",
+          "Content-Type" => "application/json"
+        }
+      end
+
+      let(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+      let(:sub) { "user_abc" }
+      let(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+
+      let!(:user) { create(:user, external_uid: sub) }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
+      end
+
+      context "パラメータが正常なとき" do
+        let(:params) do
+          {
+            group: {
+              name: "旅行精算",
+              currency: "JPY"
+            }
+          }
+        end
+
+        it "Group を作成し、作成者を OWNER として members に登録して 201 を返す" do
+         expect { do_request }.to change(Group, :count).by(1).and change(Member, :count).by(1)
+
+
+          expect(response).to have_http_status(:created)
+
+          group = Group.order(:id).last
+          expect(group.name).to eq("旅行精算")
+          expect(group.currency).to eq("JPY")
+          expect(group.public_id).to be_present
+          expect(group.invite_token).to be_present
+
+          member = Member.order(:id).last
+          expect(member.group_id).to eq(group.id)
+          expect(member.user_id).to eq(user.id)
+          expect(member.role).to eq("OWNER")
+          expect(member.active).to be(true)
+          expect(member.joined_at).to be_present
+          expect(member.left_at).to be_nil
+        end
+      end
+
+      context "name が不正なとき（空文字）" do
+        let(:params) do
+          {
+            group: {
+              name: "",
+              currency: "JPY"
+            }
+          }
+        end
+
+      it "422 を返し、Group / Member を作成しない" do
+        expect { do_request }
+          .to change(Group, :count).by(0)
+          .and change(Member, :count).by(0)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      end
+    end
+
+    context "Authorization ヘッダーが無いとき" do
+      let(:headers) { { "Content-Type" => "application/json" } }
+      let(:params) { { group: { name: "旅行精算" } } }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!)
+      end
+
+      it "401 missing_token を返す" do
+        do_request
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.media_type).to eq("application/problem+json")
+        expect(response.parsed_body).to include(
+          "title" => "Unauthorized",
+          "status" => 401,
+          "reason" => "missing_token"
+        )
+      end
+
+      it "Clerk::JwtVerifier.verify! を呼ばない" do
+        do_request
+        expect(Clerk::JwtVerifier).not_to have_received(:verify!)
+      end
+    end
+
+    context "Authorization が Bearer 形式で、verify! が失敗するとき" do
+      let(:token) { "dummy" }
+      let(:headers) do
+        {
+          "Authorization" => "Bearer #{token}",
+          "Content-Type" => "application/json"
+        }
+      end
+      let(:params) { { group: { name: "旅行精算" } } }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!)
+          .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
+      end
+
+      it "401 invalid_token を返す" do
+        do_request
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.media_type).to eq("application/problem+json")
+        expect(response.parsed_body).to include(
+          "title" => "Unauthorized",
+          "status" => 401,
+          "reason" => "invalid_token"
+        )
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe "POST /api/v1/groups", type: :request do
   subject(:do_request) { post "/api/v1/groups", params: params, headers: headers, as: :json }
 
   describe "認証" do
-    context "Authorization が Bearer 形式で、verify! が成功するとき" do
-      let(:token) { "dummy" }
-      let(:headers) do
+    context "認証成功（Authorization: Bearer / verify! 成功）" do
+      let!(:token) { "dummy" }
+      let!(:headers) do
         {
           "Authorization" => "Bearer #{token}",
           "Content-Type" => "application/json"
         }
       end
 
-      let(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
-      let(:sub) { "user_abc" }
-      let(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+      let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+      let!(:sub) { "user_abc" }
+      let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
 
       let!(:user) { create(:user, external_uid: sub) }
 
@@ -26,61 +26,65 @@ RSpec.describe "POST /api/v1/groups", type: :request do
       end
 
       context "パラメータが正常なとき" do
-        let(:params) do
-          {
-            group: {
-              name: "旅行精算",
-              currency: "JPY"
-            }
-          }
-        end
+        let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
 
-        it "Group を作成し、作成者を OWNER として members に登録して 201 を返す" do
-         expect { do_request }.to change(Group, :count).by(1).and change(Member, :count).by(1)
-
+        it "201 を返し、Group を作成し、作成者を OWNER として members に登録する" do
+          expect { do_request }
+            .to change(Group, :count).by(1)
+            .and change(Member, :count).by(1)
 
           expect(response).to have_http_status(:created)
 
-          group = Group.order(:id).last
-          expect(group.name).to eq("旅行精算")
-          expect(group.currency).to eq("JPY")
-          expect(group.public_id).to be_present
-          expect(group.invite_token).to be_present
+          created_group = Group.order(:id).last
+          created_member = Member.order(:id).last
 
-          member = Member.order(:id).last
-          expect(member.group_id).to eq(group.id)
-          expect(member.user_id).to eq(user.id)
-          expect(member.role).to eq("OWNER")
-          expect(member.active).to be(true)
-          expect(member.joined_at).to be_present
-          expect(member.left_at).to be_nil
+          expect(created_group.name).to eq("旅行精算")
+          expect(created_group.currency).to eq("JPY")
+          expect(created_group.public_id).to be_present
+          expect(created_group.invite_token).to be_present
+
+          expect(created_member.group_id).to eq(created_group.id)
+          expect(created_member.user_id).to eq(user.id)
+          expect(created_member.role).to eq("OWNER")
+          expect(created_member.active).to be(true)
+          expect(created_member.joined_at).to be_present
+          expect(created_member.left_at).to be_nil
+
+          body = response.parsed_body
+          expect(body).to include("group")
+
+          group_json = body.fetch("group")
+          expect(group_json).to include(
+            "public_id" => created_group.public_id,
+            "name" => "旅行精算",
+            "currency" => "JPY",
+            "invite_token" => created_group.invite_token
+          )
+          expect(group_json["created_at"]).to be_a(String)
+          expect(group_json["updated_at"]).to be_a(String)
         end
       end
 
       context "name が不正なとき（空文字）" do
-        let(:params) do
-          {
-            group: {
-              name: "",
-              currency: "JPY"
-            }
-          }
+        let!(:params) { { group: { name: "", currency: "JPY" } } }
+
+        it "422 を返し、Group / Member を作成しない" do
+          expect { do_request }
+            .to change(Group, :count).by(0)
+            .and change(Member, :count).by(0)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+
+          body = response.parsed_body
+          expect(body).to include("errors")
+          expect(body["errors"]).to be_an(Array)
         end
-
-      it "422 を返し、Group / Member を作成しない" do
-        expect { do_request }
-          .to change(Group, :count).by(0)
-          .and change(Member, :count).by(0)
-
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
       end
     end
 
-    context "Authorization ヘッダーが無いとき" do
-      let(:headers) { { "Content-Type" => "application/json" } }
-      let(:params) { { group: { name: "旅行精算" } } }
+    context "認証失敗（Authorization ヘッダーなし）" do
+      let!(:headers) { { "Content-Type" => "application/json" } }
+      let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
 
       before do
         allow(Clerk::JwtVerifier).to receive(:verify!)
@@ -104,15 +108,15 @@ RSpec.describe "POST /api/v1/groups", type: :request do
       end
     end
 
-    context "Authorization が Bearer 形式で、verify! が失敗するとき" do
-      let(:token) { "dummy" }
-      let(:headers) do
+    context "認証失敗（Authorization: Bearer / verify! 失敗）" do
+      let!(:token) { "dummy" }
+      let!(:headers) do
         {
           "Authorization" => "Bearer #{token}",
           "Content-Type" => "application/json"
         }
       end
-      let(:params) { { group: { name: "旅行精算" } } }
+      let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
 
       before do
         allow(Clerk::JwtVerifier).to receive(:verify!)

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe "POST /api/v1/groups", type: :request do
   describe "認証" do
     context "認証成功（Authorization: Bearer / verify! 成功）" do
       let!(:token) { "dummy" }
+      let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+      let!(:sub) { "user_abc" }
+      let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+
       let!(:headers) do
         {
           "Authorization" => "Bearer #{token}",
           "Content-Type" => "application/json"
         }
       end
-
-      let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
-      let!(:sub) { "user_abc" }
-      let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
 
       let!(:user) { create(:user, external_uid: sub) }
 
@@ -34,19 +34,24 @@ RSpec.describe "POST /api/v1/groups", type: :request do
             .and change(Member, :count).by(1)
 
           expect(response).to have_http_status(:created)
+          assert_response_schema_confirm(201)
 
           created_group = Group.order(:id).last
           created_member = Member.order(:id).last
 
-          expect(created_group.name).to eq("旅行精算")
-          expect(created_group.currency).to eq("JPY")
+          expect(created_group).to have_attributes(
+            name: "旅行精算",
+            currency: "JPY"
+          )
           expect(created_group.public_id).to be_present
           expect(created_group.invite_token).to be_present
 
-          expect(created_member.group_id).to eq(created_group.id)
-          expect(created_member.user_id).to eq(user.id)
-          expect(created_member.role).to eq("OWNER")
-          expect(created_member.active).to be(true)
+          expect(created_member).to have_attributes(
+            group_id: created_group.id,
+            user_id: user.id,
+            role: "OWNER",
+            active: true
+          )
           expect(created_member.joined_at).to be_present
           expect(created_member.left_at).to be_nil
 
@@ -68,16 +73,25 @@ RSpec.describe "POST /api/v1/groups", type: :request do
       context "name が不正なとき（空文字）" do
         let!(:params) { { group: { name: "", currency: "JPY" } } }
 
-        it "422 を返し、Group / Member を作成しない" do
+        it "422 を返し、Group / Member を作成しない（Problem Details）" do
           expect { do_request }
             .to change(Group, :count).by(0)
             .and change(Member, :count).by(0)
 
           expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(422)
 
           body = response.parsed_body
-          expect(body).to include("errors")
-          expect(body["errors"]).to be_an(Array)
+          expect(body).to include(
+            "title" => "Unprocessable Entity",
+            "status" => 422,
+            "reason" => "validation_error"
+          )
+
+          expect(body["errors"]).to be_a(Hash)
+          expect(body["errors"]).to include("name")
+          expect(body["errors"]["name"]).to be_an(Array)
         end
       end
     end
@@ -87,14 +101,18 @@ RSpec.describe "POST /api/v1/groups", type: :request do
       let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
 
       before do
+        # missing_token の場合は verify! が呼ばれない想定だが、
+        # have_received を使うために stub を用意しておく
         allow(Clerk::JwtVerifier).to receive(:verify!)
       end
 
-      it "401 missing_token を返す" do
+      it "401 missing_token を返す（Problem Details）" do
         do_request
 
         expect(response).to have_http_status(:unauthorized)
         expect(response.media_type).to eq("application/problem+json")
+        assert_response_schema_confirm(401)
+
         expect(response.parsed_body).to include(
           "title" => "Unauthorized",
           "status" => 401,
@@ -123,11 +141,13 @@ RSpec.describe "POST /api/v1/groups", type: :request do
           .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
       end
 
-      it "401 invalid_token を返す" do
+      it "401 invalid_token を返す（Problem Details）" do
         do_request
 
         expect(response).to have_http_status(:unauthorized)
         expect(response.media_type).to eq("application/problem+json")
+        assert_response_schema_confirm(401)
+
         expect(response.parsed_body).to include(
           "title" => "Unauthorized",
           "status" => 401,

--- a/backend/spec/requests/api/v1/me_spec.rb
+++ b/backend/spec/requests/api/v1/me_spec.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "securerandom"
 
 RSpec.describe "GET /api/v1/me", type: :request do
   subject(:do_request) { get "/api/v1/me", headers: headers }
-
-  # public_id は limit: 26 / null: false なので、テストでも 26 文字を作る
-  def generate_public_id
-    SecureRandom.alphanumeric(26)
-  end
 
   describe "認証" do
     describe "正常系" do
@@ -33,7 +27,7 @@ RSpec.describe "GET /api/v1/me", type: :request do
             aggregate_failures do
               expect(response).to have_http_status(:ok)
               expect(User.find_by(external_uid: sub)).to be_present
-              assert_response_schema_confirm
+              assert_response_schema_confirm(200)
             end
           end
         end
@@ -49,7 +43,7 @@ RSpec.describe "GET /api/v1/me", type: :request do
               expect(response).to have_http_status(:ok)
               expect(User.where(external_uid: sub).count).to eq(1)
               expect(User.find_by!(external_uid: sub).id).to eq(existing_user.id)
-              assert_response_schema_confirm
+              assert_response_schema_confirm(200)
             end
           end
         end
@@ -64,16 +58,19 @@ RSpec.describe "GET /api/v1/me", type: :request do
           allow(Clerk::JwtVerifier).to receive(:verify!)
         end
 
-        it "401 missing_token を返す" do
+        it "401 missing_token を返す（Problem Details）" do
           do_request
 
           aggregate_failures do
             expect(response).to have_http_status(:unauthorized)
             expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(401)
+
             expect(response.parsed_body).to include(
               "title" => "Unauthorized",
               "status" => 401,
-              "reason" => "missing_token"
+              "reason" => "missing_token",
+              "detail" => "Authorization header is missing or invalid"
             )
           end
         end
@@ -91,16 +88,19 @@ RSpec.describe "GET /api/v1/me", type: :request do
           allow(Clerk::JwtVerifier).to receive(:verify!)
         end
 
-        it "401 missing_token を返す" do
+        it "401 missing_token を返す（Problem Details）" do
           do_request
 
           aggregate_failures do
             expect(response).to have_http_status(:unauthorized)
             expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(401)
+
             expect(response.parsed_body).to include(
               "title" => "Unauthorized",
               "status" => 401,
-              "reason" => "missing_token"
+              "reason" => "missing_token",
+              "detail" => "Authorization header is missing or invalid"
             )
           end
         end
@@ -120,16 +120,19 @@ RSpec.describe "GET /api/v1/me", type: :request do
             .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
         end
 
-        it "401 invalid_token を返す" do
+        it "401 invalid_token を返す（Problem Details）" do
           do_request
 
           aggregate_failures do
             expect(response).to have_http_status(:unauthorized)
             expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(401)
+
             expect(response.parsed_body).to include(
               "title" => "Unauthorized",
               "status" => 401,
-              "reason" => "invalid_token"
+              "reason" => "invalid_token",
+              "detail" => "Token verification failed"
             )
           end
         end
@@ -144,16 +147,19 @@ RSpec.describe "GET /api/v1/me", type: :request do
             .and_raise(Clerk::JwtVerifier::VerificationError.new("invalid azp"))
         end
 
-        it "401 invalid_token を返す" do
+        it "401 invalid_token を返す（Problem Details）" do
           do_request
 
           aggregate_failures do
             expect(response).to have_http_status(:unauthorized)
             expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(401)
+
             expect(response.parsed_body).to include(
               "title" => "Unauthorized",
               "status" => 401,
-              "reason" => "invalid_token"
+              "reason" => "invalid_token",
+              "detail" => "Token verification failed"
             )
           end
         end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -112,6 +112,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}:
     get:
@@ -163,6 +165,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/members:
     get:
@@ -222,6 +226,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/members/{memberId}/leave:
     post:
@@ -245,6 +251,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/expenses:
     get:
@@ -322,6 +330,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/expenses/{expenseId}:
     get:
@@ -375,6 +385,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
     delete:
       operationId: deleteExpense
@@ -424,6 +436,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/audits:
     get:
@@ -519,7 +533,7 @@ components:
       required: true
       schema:
         type: string
-        format: uuid
+        example: MyjusiApaCFaYhQVSEAxzjs6Bw
 
     MemberId:
       name: memberId
@@ -527,7 +541,6 @@ components:
       required: true
       schema:
         type: string
-        format: uuid
 
     ExpenseId:
       name: expenseId
@@ -535,66 +548,85 @@ components:
       required: true
       schema:
         type: string
-        format: uuid
 
   responses:
     BadRequest:
       description: Bad Request
       content:
-        application/json:
+        application/problem+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "#/components/schemas/ProblemDetails"
 
     Unauthorized:
       description: Unauthorized
       content:
-        application/json:
+        application/problem+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "#/components/schemas/ProblemDetails"
 
     Forbidden:
       description: Forbidden
       content:
-        application/json:
+        application/problem+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "#/components/schemas/ProblemDetails"
 
     NotFound:
       description: Not Found
       content:
-        application/json:
+        application/problem+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "#/components/schemas/ProblemDetails"
 
     Conflict:
       description: Conflict
       content:
-        application/json:
+        application/problem+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "#/components/schemas/ProblemDetails"
+
+    UnprocessableEntity:
+      description: Unprocessable Entity
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
 
   schemas:
-    ErrorResponse:
+    ProblemDetails:
       type: object
       required:
-        - error
+        - type
+        - title
+        - status
+        - detail
+        - reason
       properties:
-        error:
+        type:
+          type: string
+          example: about:blank
+        title:
+          type: string
+          example: Unauthorized
+        status:
+          type: integer
+          example: 401
+        detail:
+          type: string
+          example: Authentication failed
+        reason:
+          type: string
+          example: missing_token
+        instance:
+          type: string
+          nullable: true
+        errors:
           type: object
-          required:
-            - code
-            - message
-          properties:
-            code:
+          nullable: true
+          additionalProperties:
+            type: array
+            items:
               type: string
-              example: bad_request
-            message:
-              type: string
-              example: invalid parameter
-            details:
-              type: array
-              items:
-                type: string
 
     ThemeMode:
       type: string
@@ -623,6 +655,7 @@ components:
         - QUEUED
         - SENT
         - FAILED
+
     User:
       type: object
       required:
@@ -636,28 +669,20 @@ components:
           format: int64
         external_uid:
           type: string
-
-        # /me で「未設定のまま返る」可能性があるので nullable にする
         name:
           type: string
           nullable: true
-
         email:
           type: string
           nullable: true
-
-        # 未設定のまま返る可能性があるなら nullable: true にする
         notify_email:
           type: boolean
           nullable: true
           default: true
-
-        # $ref のままだと nullable を直接付けられないので allOf で包む
         theme_mode:
           allOf:
             - $ref: "#/components/schemas/ThemeMode"
           nullable: true
-
         created_at:
           type: string
           format: date-time
@@ -676,22 +701,18 @@ components:
     Group:
       type: object
       required:
-        - id
+        - public_id
         - name
-        - owner_id
         - currency
         - invite_token
         - created_at
         - updated_at
       properties:
-        id:
+        public_id:
           type: string
-          format: uuid
+          example: MyjusiApaCFaYhQVSEAxzjs6Bw
         name:
           type: string
-        owner_id:
-          type: string
-          format: uuid
         currency:
           type: string
           example: JPY
@@ -758,13 +779,10 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         group_id:
           type: string
-          format: uuid
         user_id:
           type: string
-          format: uuid
         role:
           $ref: "#/components/schemas/MemberRole"
         active:
@@ -791,7 +809,6 @@ components:
       properties:
         user_id:
           type: string
-          format: uuid
         role:
           $ref: "#/components/schemas/MemberRole"
 
@@ -828,16 +845,12 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         group_id:
           type: string
-          format: uuid
         paid_by_id:
           type: string
-          format: uuid
         created_by_id:
           type: string
-          format: uuid
         amount_cents:
           type: integer
           minimum: 1
@@ -875,13 +888,10 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         expense_id:
           type: string
-          format: uuid
         user_id:
           type: string
-          format: uuid
         share_cents:
           type: integer
           minimum: 0
@@ -905,7 +915,6 @@ components:
       properties:
         user_id:
           type: string
-          format: uuid
         share_cents:
           type: integer
           minimum: 0
@@ -927,10 +936,8 @@ components:
       properties:
         paid_by_id:
           type: string
-          format: uuid
         created_by_id:
           type: string
-          format: uuid
         amount_cents:
           type: integer
           minimum: 1
@@ -1006,10 +1013,8 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         expense_id:
           type: string
-          format: uuid
         file_key:
           type: string
         content_type:
@@ -1059,14 +1064,11 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         group_id:
           type: string
-          format: uuid
           nullable: true
         actor_id:
           type: string
-          format: uuid
         action:
           type: string
           example: expense.created
@@ -1075,7 +1077,6 @@ components:
           example: Expense
         target_id:
           type: string
-          format: uuid
         diff_json:
           type: object
           nullable: true
@@ -1109,19 +1110,14 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         group_id:
           type: string
-          format: uuid
         from_id:
           type: string
-          format: uuid
         to_id:
           type: string
-          format: uuid
         expense_id:
           type: string
-          format: uuid
           nullable: true
         amount_cents:
           type: integer


### PR DESCRIPTION
## 概要
ログイン済みユーザーがグループを作成できる API を実装しました。  
作成と同時に、作成者を members に `role=OWNER / active=true` で登録します。

## 変更内容
### API
- `POST /api/v1/groups` を追加
- 認証必須（Clerk JWT / `ApplicationController` の `before_action :authenticate_with_clerk!`）
- トランザクションで以下を実行
  - `groups` 作成
  - `members` 作成（作成者, `role=OWNER`, `active=true`, `joined_at` 設定, `left_at=NULL`）

### レスポンス整形
- `render json: { group: group_json(group) }, status: :created`
- 返却属性を明示（必要な属性だけ返す）
  - `public_id`
  - `name`
  - `currency`
  - `invite_token`
  - `created_at`
  - `updated_at`

### Model
- Group: `public_id` / `invite_token` を作成時に自動生成
- Member: `joined_at` を作成時に自動設定

### Test（request spec）
- `POST /api/v1/groups`
  - 正常系：201 / Group作成 / MemberがOWNERで作成
  - 異常系：未認証 401（missing_token）
  - 異常系：name不正 422（Group/Member作成されない）
  - 異常系：verify! 失敗 401（invalid_token）
- Splittoルール対応
  - `let!` に統一
  - 1回の `do_request` で change を検証（2回呼び出しによる副作用回避）
  - 認証責務の重複を解消（Controller側の include を削除）

## 受け入れ条件（AC）チェック
- [x] 認証済みユーザーが `POST /api/v1/groups` で作成できる
- [x] 同一トランザクション内で作成者が members に OWNER として登録される
  - [x] `role=OWNER`
  - [x] `active=true`
  - [x] `joined_at` が入る
  - [x] `left_at` は NULL
- [x] `name` 不正で 422
- [x] 未認証で 401
- [x] request spec 追加

## 確認手順
### テスト
```bash
bundle exec rspec
```

## 手動確認（例）
1. Authorization付きでPOST → 201 / groupが返る
2. DB確認 → membersにOWNERが作成されている
3. AuthorizationなしでPOST → 401（missing_token）
4. name空でPOST → 422（Group/Member作成されない）

## スコープ外（今回未対応）
- グループ作成 UI
- 招待リンク生成・参加
- グループ詳細 / 一覧 API
- OWNERのみ編集などの権限制御拡張
- 監査ログ / 通知

## 関連コミット

- feat: Group作成時にpublic_idとinvite_tokenを自動生成する
- feat: Member作成時にjoined_atを自動設定する
- feat: POST /api/v1/groups のルーティングを追加
- feat: グループ作成API（POST /api/v1/groups）を実装
- refactor: 認証責務をApplicationControllerに統一し、レスポンスを明示的に整形
- test: request spec追加（let!統一 / 文言整理）