### PR TITLE
自分が所属するグループ一覧APIを実装（GET /api/v1/groups）

### DIFF
--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 class Api::V1::GroupsController < ApplicationController
+  def index
+    member_group_ids = Member.where(user_id: current_user.id, active: true).select(:group_id)
+
+    groups = Group
+      .where(id: member_group_ids)
+      .left_joins(:members)
+      .where(members: { active: true })
+      .group(
+        "groups.id, groups.public_id, groups.name, groups.currency, groups.updated_at"
+      )
+      .select(
+        "groups.public_id, groups.name, groups.currency, groups.updated_at, COUNT(members.id) AS member_count"
+      )
+      .order("groups.updated_at DESC")
+
+    render json: {
+      groups: groups.map { |g| group_list_json(g) },
+      meta: {
+        page: 1,
+        per_page: groups.size,
+        total_count: groups.size,
+        total_pages: 1
+      }
+    }, status: :ok
+  end
+
+
+
   def create
     group = nil
 
@@ -40,6 +68,18 @@ class Api::V1::GroupsController < ApplicationController
       invite_token: group.invite_token,
       created_at: group.created_at&.iso8601,
       updated_at: group.updated_at&.iso8601
+    }
+  end
+
+  # GET /groups 用（member_count 追加）
+
+  def group_list_json(group)
+    {
+      public_id: group.public_id,
+      name: group.name,
+      currency: group.currency,
+      updated_at: group.updated_at&.iso8601,
+      member_count: group.read_attribute(:member_count).to_i
     }
   end
 end

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -1,33 +1,52 @@
 # frozen_string_literal: true
 
 class Api::V1::GroupsController < ApplicationController
-  def index
-    member_group_ids = Member.where(user_id: current_user.id, active: true).select(:group_id)
+  PER_PAGE = 20
 
-    groups = Group
+  def index
+    page = params.fetch(:page, 1).to_i
+    page = 1 if page < 1
+    per_page = PER_PAGE
+
+    # 「自分が active=true で所属している group」のみを母集団として確定
+    member_group_ids = current_user
+      .members
+      .active
+      .select(:group_id)
+
+    # total_count も同じ母集団（= 自分の active 所属グループ数）
+    total_count = member_group_ids.distinct.count
+
+    #  一覧に出す group は「自分の active 所属」だけに限定した上で、
+    #  member_count は「その group の active members」を数える
+    base_scope = Group
       .where(id: member_group_ids)
-      .left_joins(:members)
-      .where(members: { active: true })
-      .group(
-        "groups.id, groups.public_id, groups.name, groups.currency, groups.updated_at"
-      )
+      .joins(:members)
+      .merge(Member.active)
+      .group("groups.id")
       .select(
-        "groups.public_id, groups.name, groups.currency, groups.updated_at, COUNT(members.id) AS member_count"
+        "groups.public_id,
+         groups.name,
+         groups.currency,
+         groups.updated_at,
+         COUNT(members.id) AS member_count"
       )
+
+    groups = base_scope
       .order("groups.updated_at DESC")
+      .limit(per_page)
+      .offset((page - 1) * per_page)
 
     render json: {
       groups: groups.map { |g| group_list_json(g) },
       meta: {
-        page: 1,
-        per_page: groups.size,
-        total_count: groups.size,
-        total_pages: 1
+        page: page,
+        per_page: per_page,
+        total_count: total_count,
+        total_pages: (total_count.to_f / per_page).ceil
       }
     }, status: :ok
   end
-
-
 
   def create
     group = nil
@@ -71,8 +90,7 @@ class Api::V1::GroupsController < ApplicationController
     }
   end
 
-  # GET /groups 用（member_count 追加）
-
+  # GET /groups 用
   def group_list_json(group)
     {
       public_id: group.public_id,

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -1,4 +1,5 @@
 class Member < ApplicationRecord
+  scope :active, -> { where(active: true) }
   belongs_to :group, inverse_of: :members
   belongs_to :user, inverse_of: :members
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "me", to: "me#show"
-      post "groups", to: "groups#create"
+      resources :groups, only: %i[index create]
     end
   end
 end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -2,157 +2,320 @@
 
 require "rails_helper"
 
-RSpec.describe "POST /api/v1/groups", type: :request do
-  subject(:do_request) { post "/api/v1/groups", params: params, headers: headers, as: :json }
+RSpec.describe "Groups API", type: :request do
+  describe "POST /api/v1/groups" do
+    subject(:do_request) { post "/api/v1/groups", params: params, headers: headers, as: :json }
 
-  describe "認証" do
-    context "認証成功（Authorization: Bearer / verify! 成功）" do
-      let!(:token) { "dummy" }
-      let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
-      let!(:sub) { "user_abc" }
-      let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+    describe "認証" do
+      context "認証成功（Authorization: Bearer / verify! 成功）" do
+        let!(:token) { "dummy" }
+        let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+        let!(:sub) { "user_abc" }
+        let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
 
-      let!(:headers) do
-        {
-          "Authorization" => "Bearer #{token}",
-          "Content-Type" => "application/json"
-        }
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        let!(:user) { create(:user, external_uid: sub) }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
+        end
+
+        context "パラメータが正常なとき" do
+          let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
+
+          it "201 を返し、Group を作成し、作成者を OWNER として members に登録する" do
+            expect { do_request }
+              .to change(Group, :count).by(1)
+              .and change(Member, :count).by(1)
+
+            expect(response).to have_http_status(:created)
+            assert_response_schema_confirm(201)
+
+            created_group = Group.order(:id).last
+            created_member = Member.order(:id).last
+
+            expect(created_group).to have_attributes(
+              name: "旅行精算",
+              currency: "JPY"
+            )
+            expect(created_group.public_id).to be_present
+            expect(created_group.invite_token).to be_present
+
+            expect(created_member).to have_attributes(
+              group_id: created_group.id,
+              user_id: user.id,
+              role: "OWNER",
+              active: true
+            )
+            expect(created_member.joined_at).to be_present
+            expect(created_member.left_at).to be_nil
+
+            body = response.parsed_body
+            expect(body).to include("group")
+
+            group_json = body.fetch("group")
+            expect(group_json).to include(
+              "public_id" => created_group.public_id,
+              "name" => "旅行精算",
+              "currency" => "JPY",
+              "invite_token" => created_group.invite_token
+            )
+            expect(group_json["created_at"]).to be_a(String)
+            expect(group_json["updated_at"]).to be_a(String)
+          end
+        end
+
+        context "name が不正なとき（空文字）" do
+          let!(:params) { { group: { name: "", currency: "JPY" } } }
+
+          it "422 を返し、Group / Member を作成しない（Problem Details）" do
+            expect { do_request }
+              .to change(Group, :count).by(0)
+              .and change(Member, :count).by(0)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(422)
+
+            body = response.parsed_body
+            expect(body).to include(
+              "title" => "Unprocessable Entity",
+              "status" => 422,
+              "reason" => "validation_error"
+            )
+
+            expect(body["errors"]).to be_a(Hash)
+            expect(body["errors"]).to include("name")
+            expect(body["errors"]["name"]).to be_an(Array)
+          end
+        end
       end
 
-      let!(:user) { create(:user, external_uid: sub) }
-
-      before do
-        allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
-      end
-
-      context "パラメータが正常なとき" do
+      context "認証失敗（Authorization ヘッダーなし）" do
+        let!(:headers) { { "Content-Type" => "application/json" } }
         let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
 
-        it "201 を返し、Group を作成し、作成者を OWNER として members に登録する" do
-          expect { do_request }
-            .to change(Group, :count).by(1)
-            .and change(Member, :count).by(1)
-
-          expect(response).to have_http_status(:created)
-          assert_response_schema_confirm(201)
-
-          created_group = Group.order(:id).last
-          created_member = Member.order(:id).last
-
-          expect(created_group).to have_attributes(
-            name: "旅行精算",
-            currency: "JPY"
-          )
-          expect(created_group.public_id).to be_present
-          expect(created_group.invite_token).to be_present
-
-          expect(created_member).to have_attributes(
-            group_id: created_group.id,
-            user_id: user.id,
-            role: "OWNER",
-            active: true
-          )
-          expect(created_member.joined_at).to be_present
-          expect(created_member.left_at).to be_nil
-
-          body = response.parsed_body
-          expect(body).to include("group")
-
-          group_json = body.fetch("group")
-          expect(group_json).to include(
-            "public_id" => created_group.public_id,
-            "name" => "旅行精算",
-            "currency" => "JPY",
-            "invite_token" => created_group.invite_token
-          )
-          expect(group_json["created_at"]).to be_a(String)
-          expect(group_json["updated_at"]).to be_a(String)
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
         end
-      end
 
-      context "name が不正なとき（空文字）" do
-        let!(:params) { { group: { name: "", currency: "JPY" } } }
+        it "401 missing_token を返す（Problem Details）" do
+          do_request
 
-        it "422 を返し、Group / Member を作成しない（Problem Details）" do
-          expect { do_request }
-            .to change(Group, :count).by(0)
-            .and change(Member, :count).by(0)
-
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unauthorized)
           expect(response.media_type).to eq("application/problem+json")
-          assert_response_schema_confirm(422)
+          assert_response_schema_confirm(401)
 
-          body = response.parsed_body
-          expect(body).to include(
-            "title" => "Unprocessable Entity",
-            "status" => 422,
-            "reason" => "validation_error"
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "missing_token"
           )
+        end
 
-          expect(body["errors"]).to be_a(Hash)
-          expect(body["errors"]).to include("name")
-          expect(body["errors"]["name"]).to be_an(Array)
+        it "Clerk::JwtVerifier.verify! を呼ばない" do
+          do_request
+          expect(Clerk::JwtVerifier).not_to have_received(:verify!)
+        end
+      end
+
+      context "認証失敗（Authorization: Bearer / verify! 失敗）" do
+        let!(:token) { "dummy" }
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
+        let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
+            .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
+        end
+
+        it "401 invalid_token を返す（Problem Details）" do
+          do_request
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(401)
+
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "invalid_token"
+          )
         end
       end
     end
+  end
 
-    context "認証失敗（Authorization ヘッダーなし）" do
-      let!(:headers) { { "Content-Type" => "application/json" } }
-      let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
+  describe "GET /api/v1/groups" do
+    subject(:do_request) { get "/api/v1/groups", headers: headers }
 
-      before do
-        # missing_token の場合は verify! が呼ばれない想定だが、
-        # have_received を使うために stub を用意しておく
-        allow(Clerk::JwtVerifier).to receive(:verify!)
+    describe "認証" do
+      context "認証成功（Authorization: Bearer / verify! 成功）" do
+        let!(:token) { "dummy" }
+        let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+        let!(:sub) { "user_abc" }
+        let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        let!(:user) { create(:user, external_uid: sub) }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
+        end
+
+        context "所属グループがあるとき" do
+          let!(:active_newer_group) { create(:group, name: "新しい", currency: "JPY", updated_at: 2.hours.ago) }
+          let!(:active_older_group) { create(:group, name: "古い", currency: "JPY", updated_at: 2.days.ago) }
+          let!(:inactive_group) { create(:group, name: "退出済み", currency: "JPY") }
+          let!(:other_users_group) { create(:group, name: "他人のグループ", currency: "JPY") }
+
+          let!(:other_user) { create(:user) }
+          let!(:third_user) { create(:user) }
+
+          before do
+            # 自分は2グループに所属（active）
+            create(:member, user: user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
+            create(:member, user: user, group: active_older_group, active: true, role: "MEMBER", joined_at: Time.current)
+
+            # newer_group は +1 人で member_count=2
+            create(:member, user: other_user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
+
+            # older_group は自分だけで member_count=1
+
+            # 退出済み（自分だが inactive）
+            create(:member, user: user, group: inactive_group, active: false, role: "MEMBER", joined_at: Time.current, left_at: Time.current)
+
+            # 他人のグループ（自分は所属してない）
+            create(:member, user: third_user, group: other_users_group, active: true, role: "MEMBER", joined_at: Time.current)
+          end
+
+          it "200 を返し、自分の active=true の所属グループのみ返す（updated_at desc）" do
+            do_request
+
+            expect(response).to have_http_status(:ok)
+            assert_response_schema_confirm(200)
+
+            body = response.parsed_body
+            expect(body).to be_a(Hash)
+            expect(body).to include("groups", "meta")
+
+            groups = body.fetch("groups")
+            expect(groups).to be_an(Array)
+            expect(groups.size).to eq(2)
+
+            # 並び順：updated_at desc
+            expect(groups[0]["public_id"]).to eq(active_newer_group.public_id)
+            expect(groups[1]["public_id"]).to eq(active_older_group.public_id)
+
+            # 返却フィールド（最小）
+            expect(groups[0]).to include(
+              "public_id" => active_newer_group.public_id,
+              "name" => "新しい",
+              "currency" => "JPY"
+            )
+            expect(groups[0]["updated_at"]).to be_a(String)
+
+            # member_count（2件とも検証）
+            expect(groups[0]["member_count"]).to eq(2)
+            expect(groups[1]["member_count"]).to eq(1)
+
+            # 退出済み・他人のグループは返らない
+            returned_ids = groups.map { |g| g.fetch("public_id") }
+            expect(returned_ids).not_to include(inactive_group.public_id)
+            expect(returned_ids).not_to include(other_users_group.public_id)
+
+            # meta も最低限の形を確認（必要なら厳密化）
+            meta = body.fetch("meta")
+            expect(meta).to be_a(Hash)
+          end
+        end
+
+        context "所属グループが0件のとき" do
+          it "200 を返し、groups: [] を返す" do
+            do_request
+
+            expect(response).to have_http_status(:ok)
+            assert_response_schema_confirm(200)
+
+            body = response.parsed_body
+            expect(body).to be_a(Hash)
+            expect(body).to include("groups", "meta")
+            expect(body.fetch("groups")).to eq([])
+          end
+        end
       end
 
-      it "401 missing_token を返す（Problem Details）" do
-        do_request
+      context "認証失敗（Authorization ヘッダーなし）" do
+        let!(:headers) { { "Content-Type" => "application/json" } }
 
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.media_type).to eq("application/problem+json")
-        assert_response_schema_confirm(401)
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
+        end
 
-        expect(response.parsed_body).to include(
-          "title" => "Unauthorized",
-          "status" => 401,
-          "reason" => "missing_token"
-        )
+        it "401 missing_token を返す（Problem Details）" do
+          do_request
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(401)
+
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "missing_token"
+          )
+        end
+
+        it "Clerk::JwtVerifier.verify! を呼ばない" do
+          do_request
+          expect(Clerk::JwtVerifier).not_to have_received(:verify!)
+        end
       end
 
-      it "Clerk::JwtVerifier.verify! を呼ばない" do
-        do_request
-        expect(Clerk::JwtVerifier).not_to have_received(:verify!)
-      end
-    end
+      context "認証失敗（Authorization: Bearer / verify! 失敗）" do
+        let!(:token) { "dummy" }
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
 
-    context "認証失敗（Authorization: Bearer / verify! 失敗）" do
-      let!(:token) { "dummy" }
-      let!(:headers) do
-        {
-          "Authorization" => "Bearer #{token}",
-          "Content-Type" => "application/json"
-        }
-      end
-      let!(:params) { { group: { name: "旅行精算", currency: "JPY" } } }
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
+            .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
+        end
 
-      before do
-        allow(Clerk::JwtVerifier).to receive(:verify!)
-          .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
-      end
+        it "401 invalid_token を返す（Problem Details）" do
+          do_request
 
-      it "401 invalid_token を返す（Problem Details）" do
-        do_request
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(401)
 
-        expect(response).to have_http_status(:unauthorized)
-        expect(response.media_type).to eq("application/problem+json")
-        assert_response_schema_confirm(401)
-
-        expect(response.parsed_body).to include(
-          "title" => "Unauthorized",
-          "status" => 401,
-          "reason" => "invalid_token"
-        )
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "invalid_token"
+          )
+        end
       end
     end
   end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -192,17 +192,13 @@ RSpec.describe "Groups API", type: :request do
           let!(:third_user) { create(:user) }
 
           before do
-            # 自分は2グループに所属（active）
             create(:member, user: user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
             create(:member, user: user, group: active_older_group, active: true, role: "MEMBER", joined_at: Time.current)
 
-            # newer_group は +1 人で member_count=2
             create(:member, user: other_user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
 
-            # 退出済み（自分だが inactive）
             create(:member, user: user, group: inactive_group, active: false, role: "MEMBER", joined_at: Time.current, left_at: Time.current)
 
-            # 他人のグループ（自分は所属してない）
             create(:member, user: third_user, group: other_users_group, active: true, role: "MEMBER", joined_at: Time.current)
           end
 
@@ -220,11 +216,9 @@ RSpec.describe "Groups API", type: :request do
             expect(groups).to be_an(Array)
             expect(groups.size).to eq(2)
 
-            # 並び順：updated_at desc
             expect(groups[0]["public_id"]).to eq(active_newer_group.public_id)
             expect(groups[1]["public_id"]).to eq(active_older_group.public_id)
 
-            # 返却フィールド（最小）
             expect(groups[0]).to include(
               "public_id" => active_newer_group.public_id,
               "name" => "新しい",
@@ -232,20 +226,16 @@ RSpec.describe "Groups API", type: :request do
             )
             expect(groups[0]["updated_at"]).to be_a(String)
 
-            # member_count（2件とも検証）
             expect(groups[0]["member_count"]).to eq(2)
             expect(groups[1]["member_count"]).to eq(1)
 
-            # 退出済み・他人のグループは返らない
             returned_ids = groups.map { |g| g.fetch("public_id") }
             expect(returned_ids).not_to include(inactive_group.public_id)
             expect(returned_ids).not_to include(other_users_group.public_id)
 
-            # meta（ページネーション形式）
             meta = body.fetch("meta")
-            expect(meta).to be_a(Hash)
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("per_page")).to eq(20)
             expect(meta.fetch("total_count")).to eq(2)
             expect(meta.fetch("total_pages")).to eq(1)
           end
@@ -259,17 +249,15 @@ RSpec.describe "Groups API", type: :request do
             assert_response_schema_confirm(200)
 
             body = response.parsed_body
-            expect(body).to be_a(Hash)
             expect(body).to include("groups", "meta")
             expect(body.fetch("groups")).to eq([])
 
             meta = body.fetch("meta")
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("per_page")).to eq(20)
             expect(meta.fetch("total_count")).to eq(0)
 
-            # 実装方針が (0.to_f / 20).ceil => 0 の場合はこちらに合わせる
-            # total_pages を最低 1 に丸める実装なら 1 に変更してください
+            # 実装が ceil(0/20)=0 の場合
             expect(meta.fetch("total_pages")).to eq(0)
           end
         end
@@ -278,11 +266,12 @@ RSpec.describe "Groups API", type: :request do
           let!(:other_user) { create(:user) }
 
           before do
-            # 自分が active で所属するグループを 25 件作る（updated_at desc になるよう時間を振る）
-            # さらに member_count を 2（自分 + other_user）にする
             base_time = 2.days.ago
 
-            25.times do |i|
+            # 21件あれば十分：
+            # - page=1 => 20件
+            # - page=2 => 1件
+            21.times do |i|
               group = create(
                 :group,
                 name: "G#{i}",
@@ -309,7 +298,7 @@ RSpec.describe "Groups API", type: :request do
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(1)
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_count")).to eq(21)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -317,19 +306,19 @@ RSpec.describe "Groups API", type: :request do
           context "page=2 のとき" do
             let(:query) { { page: 2 } }
 
-            it "2ページ目として 5 件返す（offset が効く）" do
+            it "2ページ目として 1 件返す（offset が効く）" do
               do_request
 
               expect(response).to have_http_status(:ok)
               assert_response_schema_confirm(200)
 
               body = response.parsed_body
-              expect(body.fetch("groups").size).to eq(5)
+              expect(body.fetch("groups").size).to eq(1)
 
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(2)
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_count")).to eq(21)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -362,7 +351,7 @@ RSpec.describe "Groups API", type: :request do
 
               meta = body.fetch("meta")
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_count")).to eq(21)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -158,7 +158,9 @@ RSpec.describe "Groups API", type: :request do
   end
 
   describe "GET /api/v1/groups" do
-    subject(:do_request) { get "/api/v1/groups", headers: headers }
+    subject(:do_request) { get "/api/v1/groups", params: query, headers: headers }
+
+    let(:query) { {} }
 
     describe "認証" do
       context "認証成功（Authorization: Bearer / verify! 成功）" do
@@ -180,7 +182,7 @@ RSpec.describe "Groups API", type: :request do
           allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
         end
 
-        context "所属グループがあるとき" do
+        context "所属グループがあるとき（基本）" do
           let!(:active_newer_group) { create(:group, name: "新しい", currency: "JPY", updated_at: 2.hours.ago) }
           let!(:active_older_group) { create(:group, name: "古い", currency: "JPY", updated_at: 2.days.ago) }
           let!(:inactive_group) { create(:group, name: "退出済み", currency: "JPY") }
@@ -196,8 +198,6 @@ RSpec.describe "Groups API", type: :request do
 
             # newer_group は +1 人で member_count=2
             create(:member, user: other_user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
-
-            # older_group は自分だけで member_count=1
 
             # 退出済み（自分だが inactive）
             create(:member, user: user, group: inactive_group, active: false, role: "MEMBER", joined_at: Time.current, left_at: Time.current)
@@ -241,14 +241,18 @@ RSpec.describe "Groups API", type: :request do
             expect(returned_ids).not_to include(inactive_group.public_id)
             expect(returned_ids).not_to include(other_users_group.public_id)
 
-            # meta も最低限の形を確認（必要なら厳密化）
+            # meta（ページネーション形式）
             meta = body.fetch("meta")
             expect(meta).to be_a(Hash)
+            expect(meta.fetch("page")).to eq(1)
+            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("total_count")).to eq(2)
+            expect(meta.fetch("total_pages")).to eq(1)
           end
         end
 
         context "所属グループが0件のとき" do
-          it "200 を返し、groups: [] を返す" do
+          it "200 を返し、groups: [] と meta(per_page=20) を返す" do
             do_request
 
             expect(response).to have_http_status(:ok)
@@ -258,6 +262,109 @@ RSpec.describe "Groups API", type: :request do
             expect(body).to be_a(Hash)
             expect(body).to include("groups", "meta")
             expect(body.fetch("groups")).to eq([])
+
+            meta = body.fetch("meta")
+            expect(meta.fetch("page")).to eq(1)
+            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("total_count")).to eq(0)
+
+            # 実装方針が (0.to_f / 20).ceil => 0 の場合はこちらに合わせる
+            # total_pages を最低 1 に丸める実装なら 1 に変更してください
+            expect(meta.fetch("total_pages")).to eq(0)
+          end
+        end
+
+        context "ページネーション（per_page 固定 20）" do
+          let!(:other_user) { create(:user) }
+
+          before do
+            # 自分が active で所属するグループを 25 件作る（updated_at desc になるよう時間を振る）
+            # さらに member_count を 2（自分 + other_user）にする
+            base_time = 2.days.ago
+
+            25.times do |i|
+              group = create(
+                :group,
+                name: "G#{i}",
+                currency: "JPY",
+                updated_at: base_time + i.minutes
+              )
+              create(:member, user: user, group: group, active: true, role: "MEMBER", joined_at: Time.current)
+              create(:member, user: other_user, group: group, active: true, role: "MEMBER", joined_at: Time.current)
+            end
+          end
+
+          context "page を指定しないとき" do
+            let(:query) { {} }
+
+            it "1ページ目として 20 件返し、meta.per_page は 20（固定）" do
+              do_request
+
+              expect(response).to have_http_status(:ok)
+              assert_response_schema_confirm(200)
+
+              body = response.parsed_body
+              expect(body.fetch("groups").size).to eq(20)
+
+              meta = body.fetch("meta")
+              expect(meta.fetch("page")).to eq(1)
+              expect(meta.fetch("per_page")).to eq(20)
+              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_pages")).to eq(2)
+            end
+          end
+
+          context "page=2 のとき" do
+            let(:query) { { page: 2 } }
+
+            it "2ページ目として 5 件返す（offset が効く）" do
+              do_request
+
+              expect(response).to have_http_status(:ok)
+              assert_response_schema_confirm(200)
+
+              body = response.parsed_body
+              expect(body.fetch("groups").size).to eq(5)
+
+              meta = body.fetch("meta")
+              expect(meta.fetch("page")).to eq(2)
+              expect(meta.fetch("per_page")).to eq(20)
+              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_pages")).to eq(2)
+            end
+          end
+
+          context "page が 0 以下のとき" do
+            let(:query) { { page: 0 } }
+
+            it "page は 1 扱いになる" do
+              do_request
+
+              expect(response).to have_http_status(:ok)
+              assert_response_schema_confirm(200)
+
+              meta = response.parsed_body.fetch("meta")
+              expect(meta.fetch("page")).to eq(1)
+            end
+          end
+
+          context "per_page を指定しても無視する設計のとき" do
+            let(:query) { { per_page: 5 } }
+
+            it "返却件数は 20 のまま、meta.per_page も 20 のまま" do
+              do_request
+
+              expect(response).to have_http_status(:ok)
+              assert_response_schema_confirm(200)
+
+              body = response.parsed_body
+              expect(body.fetch("groups").size).to eq(20)
+
+              meta = body.fetch("meta")
+              expect(meta.fetch("per_page")).to eq(20)
+              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("total_pages")).to eq(2)
+            end
           end
         end
       end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -192,13 +192,17 @@ RSpec.describe "Groups API", type: :request do
           let!(:third_user) { create(:user) }
 
           before do
+            # 自分は2グループに所属（active）
             create(:member, user: user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
             create(:member, user: user, group: active_older_group, active: true, role: "MEMBER", joined_at: Time.current)
 
+            # newer_group は +1 人で member_count=2
             create(:member, user: other_user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
 
+            # 退出済み（自分だが inactive）
             create(:member, user: user, group: inactive_group, active: false, role: "MEMBER", joined_at: Time.current, left_at: Time.current)
 
+            # 他人のグループ（自分は所属してない）
             create(:member, user: third_user, group: other_users_group, active: true, role: "MEMBER", joined_at: Time.current)
           end
 
@@ -216,9 +220,11 @@ RSpec.describe "Groups API", type: :request do
             expect(groups).to be_an(Array)
             expect(groups.size).to eq(2)
 
+            # 並び順：updated_at desc
             expect(groups[0]["public_id"]).to eq(active_newer_group.public_id)
             expect(groups[1]["public_id"]).to eq(active_older_group.public_id)
 
+            # 返却フィールド（最小）
             expect(groups[0]).to include(
               "public_id" => active_newer_group.public_id,
               "name" => "新しい",
@@ -226,16 +232,20 @@ RSpec.describe "Groups API", type: :request do
             )
             expect(groups[0]["updated_at"]).to be_a(String)
 
+            # member_count（2件とも検証）
             expect(groups[0]["member_count"]).to eq(2)
             expect(groups[1]["member_count"]).to eq(1)
 
+            # 退出済み・他人のグループは返らない
             returned_ids = groups.map { |g| g.fetch("public_id") }
             expect(returned_ids).not_to include(inactive_group.public_id)
             expect(returned_ids).not_to include(other_users_group.public_id)
 
+            # meta（ページネーション形式）
             meta = body.fetch("meta")
+            expect(meta).to be_a(Hash)
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20)
+            expect(meta.fetch("per_page")).to eq(20) # 固定
             expect(meta.fetch("total_count")).to eq(2)
             expect(meta.fetch("total_pages")).to eq(1)
           end
@@ -249,15 +259,17 @@ RSpec.describe "Groups API", type: :request do
             assert_response_schema_confirm(200)
 
             body = response.parsed_body
+            expect(body).to be_a(Hash)
             expect(body).to include("groups", "meta")
             expect(body.fetch("groups")).to eq([])
 
             meta = body.fetch("meta")
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20)
+            expect(meta.fetch("per_page")).to eq(20) # 固定
             expect(meta.fetch("total_count")).to eq(0)
 
-            # 実装が ceil(0/20)=0 の場合
+            # 実装方針が (0.to_f / 20).ceil => 0 の場合はこちらに合わせる
+            # total_pages を最低 1 に丸める実装なら 1 に変更してください
             expect(meta.fetch("total_pages")).to eq(0)
           end
         end
@@ -266,12 +278,11 @@ RSpec.describe "Groups API", type: :request do
           let!(:other_user) { create(:user) }
 
           before do
+            # 自分が active で所属するグループを 25 件作る（updated_at desc になるよう時間を振る）
+            # さらに member_count を 2（自分 + other_user）にする
             base_time = 2.days.ago
 
-            # 21件あれば十分：
-            # - page=1 => 20件
-            # - page=2 => 1件
-            21.times do |i|
+            25.times do |i|
               group = create(
                 :group,
                 name: "G#{i}",
@@ -298,7 +309,7 @@ RSpec.describe "Groups API", type: :request do
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(1)
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(21)
+              expect(meta.fetch("total_count")).to eq(25)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -306,19 +317,19 @@ RSpec.describe "Groups API", type: :request do
           context "page=2 のとき" do
             let(:query) { { page: 2 } }
 
-            it "2ページ目として 1 件返す（offset が効く）" do
+            it "2ページ目として 5 件返す（offset が効く）" do
               do_request
 
               expect(response).to have_http_status(:ok)
               assert_response_schema_confirm(200)
 
               body = response.parsed_body
-              expect(body.fetch("groups").size).to eq(1)
+              expect(body.fetch("groups").size).to eq(5)
 
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(2)
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(21)
+              expect(meta.fetch("total_count")).to eq(25)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -351,7 +362,7 @@ RSpec.describe "Groups API", type: :request do
 
               meta = body.fetch("meta")
               expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(21)
+              expect(meta.fetch("total_count")).to eq(25)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -192,17 +192,13 @@ RSpec.describe "Groups API", type: :request do
           let!(:third_user) { create(:user) }
 
           before do
-            # 自分は2グループに所属（active）
             create(:member, user: user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
             create(:member, user: user, group: active_older_group, active: true, role: "MEMBER", joined_at: Time.current)
 
-            # newer_group は +1 人で member_count=2
             create(:member, user: other_user, group: active_newer_group, active: true, role: "MEMBER", joined_at: Time.current)
 
-            # 退出済み（自分だが inactive）
             create(:member, user: user, group: inactive_group, active: false, role: "MEMBER", joined_at: Time.current, left_at: Time.current)
 
-            # 他人のグループ（自分は所属してない）
             create(:member, user: third_user, group: other_users_group, active: true, role: "MEMBER", joined_at: Time.current)
           end
 
@@ -220,11 +216,9 @@ RSpec.describe "Groups API", type: :request do
             expect(groups).to be_an(Array)
             expect(groups.size).to eq(2)
 
-            # 並び順：updated_at desc
             expect(groups[0]["public_id"]).to eq(active_newer_group.public_id)
             expect(groups[1]["public_id"]).to eq(active_older_group.public_id)
 
-            # 返却フィールド（最小）
             expect(groups[0]).to include(
               "public_id" => active_newer_group.public_id,
               "name" => "新しい",
@@ -232,20 +226,17 @@ RSpec.describe "Groups API", type: :request do
             )
             expect(groups[0]["updated_at"]).to be_a(String)
 
-            # member_count（2件とも検証）
             expect(groups[0]["member_count"]).to eq(2)
             expect(groups[1]["member_count"]).to eq(1)
 
-            # 退出済み・他人のグループは返らない
             returned_ids = groups.map { |g| g.fetch("public_id") }
             expect(returned_ids).not_to include(inactive_group.public_id)
             expect(returned_ids).not_to include(other_users_group.public_id)
 
-            # meta（ページネーション形式）
             meta = body.fetch("meta")
             expect(meta).to be_a(Hash)
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("per_page")).to eq(20)
             expect(meta.fetch("total_count")).to eq(2)
             expect(meta.fetch("total_pages")).to eq(1)
           end
@@ -265,51 +256,48 @@ RSpec.describe "Groups API", type: :request do
 
             meta = body.fetch("meta")
             expect(meta.fetch("page")).to eq(1)
-            expect(meta.fetch("per_page")).to eq(20) # 固定
+            expect(meta.fetch("per_page")).to eq(20)
             expect(meta.fetch("total_count")).to eq(0)
-
-            # 実装方針が (0.to_f / 20).ceil => 0 の場合はこちらに合わせる
-            # total_pages を最低 1 に丸める実装なら 1 に変更してください
             expect(meta.fetch("total_pages")).to eq(0)
           end
         end
 
-        context "ページネーション（per_page 固定 20）" do
+        context "ページネーション（CI負荷対策：stub_const で per_page を小さく）" do
           let!(:other_user) { create(:user) }
 
           before do
-            # 自分が active で所属するグループを 25 件作る（updated_at desc になるよう時間を振る）
-            # さらに member_count を 2（自分 + other_user）にする
+            stub_const("Api::V1::GroupsController::PER_PAGE", 3)
+
+            # 5件あれば十分：
+            # - page=1 => 3件
+            # - page=2 => 2件
+            @groups = create_list(:group, 5, currency: "JPY")
             base_time = 2.days.ago
 
-            25.times do |i|
-              group = create(
-                :group,
-                name: "G#{i}",
-                currency: "JPY",
-                updated_at: base_time + i.minutes
-              )
-              create(:member, user: user, group: group, active: true, role: "MEMBER", joined_at: Time.current)
-              create(:member, user: other_user, group: group, active: true, role: "MEMBER", joined_at: Time.current)
+            @groups.each_with_index do |g, i|
+              g.update!(updated_at: base_time + i.minutes)
+
+              create(:member, user: user, group: g, active: true, role: "MEMBER", joined_at: Time.current)
+              create(:member, user: other_user, group: g, active: true, role: "MEMBER", joined_at: Time.current)
             end
           end
 
           context "page を指定しないとき" do
             let(:query) { {} }
 
-            it "1ページ目として 20 件返し、meta.per_page は 20（固定）" do
+            it "1ページ目として 3 件返し、meta.per_page も 3 になる" do
               do_request
 
               expect(response).to have_http_status(:ok)
               assert_response_schema_confirm(200)
 
               body = response.parsed_body
-              expect(body.fetch("groups").size).to eq(20)
+              expect(body.fetch("groups").size).to eq(3)
 
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(1)
-              expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("per_page")).to eq(3)
+              expect(meta.fetch("total_count")).to eq(5)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -317,19 +305,19 @@ RSpec.describe "Groups API", type: :request do
           context "page=2 のとき" do
             let(:query) { { page: 2 } }
 
-            it "2ページ目として 5 件返す（offset が効く）" do
+            it "2ページ目として 2 件返す（offset が効く）" do
               do_request
 
               expect(response).to have_http_status(:ok)
               assert_response_schema_confirm(200)
 
               body = response.parsed_body
-              expect(body.fetch("groups").size).to eq(5)
+              expect(body.fetch("groups").size).to eq(2)
 
               meta = body.fetch("meta")
               expect(meta.fetch("page")).to eq(2)
-              expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("per_page")).to eq(3)
+              expect(meta.fetch("total_count")).to eq(5)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end
@@ -349,20 +337,20 @@ RSpec.describe "Groups API", type: :request do
           end
 
           context "per_page を指定しても無視する設計のとき" do
-            let(:query) { { per_page: 5 } }
+            let(:query) { { per_page: 1 } }
 
-            it "返却件数は 20 のまま、meta.per_page も 20 のまま" do
+            it "返却件数は 3 のまま、meta.per_page も 3 のまま" do
               do_request
 
               expect(response).to have_http_status(:ok)
               assert_response_schema_confirm(200)
 
               body = response.parsed_body
-              expect(body.fetch("groups").size).to eq(20)
+              expect(body.fetch("groups").size).to eq(3)
 
               meta = body.fetch("meta")
-              expect(meta.fetch("per_page")).to eq(20)
-              expect(meta.fetch("total_count")).to eq(25)
+              expect(meta.fetch("per_page")).to eq(3)
+              expect(meta.fetch("total_count")).to eq(5)
               expect(meta.fetch("total_pages")).to eq(2)
             end
           end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -77,6 +77,8 @@ paths:
       tags:
         - Groups
       summary: グループ一覧（自分が所属する active=true のみ）
+      parameters:
+        - $ref: "#/components/parameters/Page"
       responses:
         "200":
           description: OK
@@ -86,6 +88,7 @@ paths:
                 $ref: "#/components/schemas/GroupListResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
     post:
       operationId: createGroup
       tags:
@@ -1178,11 +1181,17 @@ components:
       properties:
         page:
           type: integer
+          minimum: 1
+          example: 1
         per_page:
           type: integer
+          enum: [20]
+          example: 20
         total_count:
           type: integer
           nullable: true
+          example: 42
         total_pages:
           type: integer
           nullable: true
+          example: 3

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1185,7 +1185,6 @@ components:
           example: 1
         per_page:
           type: integer
-          enum: [20]
           example: 20
         total_count:
           type: integer

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -76,10 +76,7 @@ paths:
       operationId: listGroups
       tags:
         - Groups
-      summary: グループ一覧
-      parameters:
-        - $ref: "#/components/parameters/Page"
-        - $ref: "#/components/parameters/PerPage"
+      summary: グループ一覧（自分が所属する active=true のみ）
       responses:
         "200":
           description: OK
@@ -89,7 +86,6 @@ paths:
                 $ref: "#/components/schemas/GroupListResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
     post:
       operationId: createGroup
       tags:
@@ -725,6 +721,32 @@ components:
           type: string
           format: date-time
 
+    GroupListItem:
+      type: object
+      required:
+        - public_id
+        - name
+        - currency
+        - updated_at
+        - member_count
+      properties:
+        public_id:
+          type: string
+          example: "01H00000000000000000000012"
+        name:
+          type: string
+          example: "新しい"
+        currency:
+          type: string
+          example: "JPY"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2026-02-21T23:10:38Z"
+        member_count:
+          type: integer
+          example: 2
+
     GroupCreateRequest:
       type: object
       required:
@@ -761,7 +783,7 @@ components:
         groups:
           type: array
           items:
-            $ref: "#/components/schemas/Group"
+            $ref: "#/components/schemas/GroupListItem"
         meta:
           $ref: "#/components/schemas/PaginationMeta"
 


### PR DESCRIPTION
## 概要

グループ一覧API（GET /api/v1/groups）を実装しました。

ログイン済みユーザーが「自分が所属している active=true のグループのみ」を取得できるAPIです。

---

## 実装内容

### API
- GET /api/v1/groups を追加
- 認証必須（Clerk JWT）
- 返却対象：
  - members.user_id = current_user.id
  - members.active = true
- 並び順：updated_at DESC

### レスポンス形式
OpenAPI 定義に合わせ、`GroupListResponse` 形式で返却します。

```json
{
  "groups": [
    {
      "public_id": "01H...",
      "name": "旅行精算",
      "currency": "JPY",
      "updated_at": "2026-02-21T23:10:38Z",
      "member_count": 2
    }
  ],
  "meta": {
    "page": 1,
    "per_page": 2,
    "total_count": 2,
    "total_pages": 1
  }
}
```
- 0件の場合は groups: [] を返します
- member_count は active=true のメンバー数

---
## テスト

request spec を追加・整理しました。

### 正常系

- 自分が所属する active=true のグループのみ返る
- updated_at DESC で返る
- member_count が正しく返る
- 所属0件の場合は `groups: []`

### 異常系

- 未認証 → 401
- トークン不正 → 401

---

## スコープ外

- ページネーションの実装
- グループ詳細API
- UI実装
- 招待機能
- 権限制御の拡張

