### PR TITLE
feat(frontend): Issue #13 グループ作成画面（フォームのみ・API未接続）を追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.36.7",
+        "@hookform/resolvers": "^5.2.2",
         "next": "16.1.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "react-hook-form": "^7.71.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -70,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -557,6 +559,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1345,6 +1359,12 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1673,7 +1693,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1733,7 +1752,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2233,7 +2251,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2574,7 +2591,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3151,7 +3167,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3353,7 +3368,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5117,7 +5131,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -5564,7 +5577,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5574,12 +5586,27 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -6298,7 +6325,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6461,7 +6487,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6741,12 +6766,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,12 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.36.7",
+    "@hookform/resolvers": "^5.2.2",
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "react-hook-form": "^7.71.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/app/(dashboard)/groups/new/_components/GroupCreateForm.tsx
+++ b/frontend/src/app/(dashboard)/groups/new/_components/GroupCreateForm.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useForm, type SubmitHandler } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { ButtonLink } from "@/components/ui/ButtonLink"
+import {
+  groupCreateSchema,
+  type GroupCreateValues,
+} from "../_schemas/groupCreateSchema"
+
+const styles = {
+  card: "rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_0_0_1px_rgba(255,255,255,0.03)] backdrop-blur",
+  field: "mt-5",
+  label: "text-sm font-semibold text-white/90",
+  input:
+    "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/40 outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-300/20",
+  select:
+    "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-300/20",
+  help: "mt-2 text-xs text-white/50",
+  error: "mt-2 text-xs text-rose-200",
+  actions: "mt-6 flex flex-wrap items-center gap-3",
+  submit:
+    "inline-flex items-center justify-center rounded-full bg-emerald-500 px-6 py-3 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50",
+  notice:
+    "mt-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/80",
+  disabledLink: "pointer-events-none opacity-50",
+} as const
+
+const currencyOptions = [
+  { value: "JPY", label: "JPY（円）" },
+  { value: "USD", label: "USD（ドル）" },
+  { value: "EUR", label: "EUR（ユーロ）" },
+] as const
+
+type CreateGroupPayload = {
+  group: {
+    name: string
+    currency: string
+  }
+}
+
+/**
+ * 将来 API 接続する時に差分を小さくするため、payload 生成は関数でまとめる。
+ * バックエンドの `group_params`（params.require(:group).permit(:name, :currency)）に合わせる。
+ */
+function buildCreateGroupPayload(values: GroupCreateValues): CreateGroupPayload {
+  return {
+    group: {
+      name: values.name,
+      currency: values.currency,
+    },
+  }
+}
+
+/**
+ * API未接続のため、送信中状態（isSubmitting）の UI を確認する目的で擬似的に待機する。
+ * API接続時は、この sleep を実際の POST リクエストに置き換える。
+ */
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+export function GroupCreateForm() {
+  const [notice, setNotice] = useState<string>("")
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<GroupCreateValues>({
+    resolver: zodResolver(groupCreateSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+      currency: "JPY",
+    },
+  })
+
+  /**
+   * #13 方針：UIのみ先行（API未接続）
+   * - submit で「ボタンが反応する」「送信中UIが出る」「成功メッセージが出る」を確認する
+   * - 入力値は “保持する” 前提（リセットしない）
+   */
+  const onSubmit: SubmitHandler<GroupCreateValues> = useCallback(async (values) => {
+    setNotice("")
+
+    await sleep(600)
+
+    const payload = buildCreateGroupPayload(values)
+    console.log("[mock submit] POST /api/v1/groups payload:", payload)
+
+    setNotice(
+      `仮: 「${values.name}」を作成しました（currency: ${values.currency} / API未接続）`
+    )
+
+    // 値は保持する（#13の前提）：reset() は呼ばない
+  }, [])
+
+  return (
+    <section className={styles.card} aria-label="グループ作成フォーム">
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="name">
+            グループ名 <span className="text-rose-200">*</span>
+          </label>
+          <input
+            id="name"
+            type="text"
+            placeholder="例：大阪旅行精算"
+            className={styles.input}
+            {...register("name")}
+            aria-invalid={Boolean(errors.name)}
+          />
+          <p className={styles.help}>1〜50文字</p>
+          {errors.name?.message ? (
+            <p className={styles.error}>{errors.name.message}</p>
+          ) : null}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="currency">
+            通貨 <span className="text-rose-200">*</span>
+          </label>
+          <select
+            id="currency"
+            className={styles.select}
+            {...register("currency")}
+            aria-invalid={Boolean(errors.currency)}
+          >
+            {currencyOptions.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <p className={styles.help}>
+            未指定の場合、バックエンドではデフォルト（例：JPY）になります
+          </p>
+          {errors.currency?.message ? (
+            <p className={styles.error}>{errors.currency.message}</p>
+          ) : null}
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            type="submit"
+            className={styles.submit}
+            disabled={!isValid || isSubmitting}
+          >
+            {isSubmitting ? "作成中..." : "作成する（仮）"}
+          </button>
+
+          <ButtonLink
+            href="/groups"
+            variant="secondary"
+            size="md"
+            className={isSubmitting ? styles.disabledLink : ""}
+            ariaLabel="グループ一覧に戻る"
+          >
+            一覧に戻る
+          </ButtonLink>
+
+          <span className="text-xs text-white/50">
+            ※ API接続は次Issueで実装します
+          </span>
+        </div>
+
+        {notice ? <div className={styles.notice}>{notice}</div> : null}
+      </form>
+    </section>
+  )
+}

--- a/frontend/src/app/(dashboard)/groups/new/_schemas/groupCreateSchema.ts
+++ b/frontend/src/app/(dashboard)/groups/new/_schemas/groupCreateSchema.ts
@@ -5,7 +5,6 @@ export const groupCreateSchema = z.object({
     .string()
     .min(1, "グループ名は必須です")
     .max(50, "グループ名は50文字以内にしてください"),
-  description: z.string().max(200, "説明は200文字以内にしてください").optional(),
   currency: z
     .string()
     .min(1, "通貨は必須です")

--- a/frontend/src/app/(dashboard)/groups/new/_schemas/groupCreateSchema.ts
+++ b/frontend/src/app/(dashboard)/groups/new/_schemas/groupCreateSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod"
+
+export const groupCreateSchema = z.object({
+  name: z
+    .string()
+    .min(1, "グループ名は必須です")
+    .max(50, "グループ名は50文字以内にしてください"),
+  description: z.string().max(200, "説明は200文字以内にしてください").optional(),
+  currency: z
+    .string()
+    .min(1, "通貨は必須です")
+    .max(10, "通貨コードが長すぎます"),
+})
+
+export type GroupCreateValues = z.infer<typeof groupCreateSchema>

--- a/frontend/src/app/(dashboard)/groups/new/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/new/page.tsx
@@ -1,0 +1,24 @@
+import { GroupCreateForm } from "./_components/GroupCreateForm"
+
+export default function GroupCreatePage() {
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <div className="relative mx-auto max-w-2xl px-6 py-10">
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold">
+            グループ作成 <span className="text-emerald-300">Splitto</span>
+          </h1>
+          <p className="mt-2 text-sm text-white/70">
+            まずはグループ名を入力してください（この画面はUIのみで、API接続は次Issueで対応します）
+          </p>
+        </header>
+
+        <GroupCreateForm />
+
+        <p className="mt-6 text-xs text-white/50">
+          ※ このIssueでは「送信中表示・バリデーション・仮submit」までが対象です
+        </p>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## 概要
グループ作成画面（入力フォーム）を実装しました。  
本PRでは **API接続は行わず**、UI・入力バリデーション・送信中状態の表現までを対象にしています。

## 目的
- 次Issue（UI → API接続）でPRが肥大化しないよう、UIを先に切り出す
- スプリントレビューで「グループ作成画面ができた」を画面操作で見せられる状態にする

## スコープ（このPRでやったこと）
### 画面
- グループ作成ページを追加（`/groups/new`）

### フォーム
- 入力項目を実装
  - `name`（必須）
  - `currency`（必須 / デフォルト `JPY`）

### 入力バリデーション
- `name` 必須（1〜50文字）
- `currency` 必須

### 送信中UI（API未接続）
- Submit時は仮のハンドラで動作確認（`console.log` + notice表示）
- 送信中状態を確認できるように以下を実装
  - Submitボタン disabled
  - ボタン文言を `作成中...` に切り替え
  - 仮の `sleep` で送信中状態を再現

### 依存追加
- `react-hook-form`
- `zod`
- `@hookform/resolvers`

## スコープ外（このPRではやらない）
- POST `/api/v1/groups` への接続
- 作成後の遷移（一覧/詳細）
- 招待リンク
- デザインの作り込み（最低限）

## 受け入れ条件（Acceptance Criteria）
- [ ] グループ作成ページにアクセスできる
- [ ] `name` を入力しないと送信できない
- [ ] `name` を入力すると送信できる（API未接続でもボタンが反応する）
- [ ] 送信中のUI状態（disabled / loading）が確認できる

## 確認手順（レビュー観点）
1. グループ作成ページを開く（`/groups/new`）
2. `name` 未入力で送信 → エラー表示 & 送信不可
3. `name` 入力して送信 → 仮の成功フィードバック（notice）表示
4. 送信中の状態（ボタン disabled / 文言が作成中...）が表示される
