### PR TITLE
feat(frontend): グループ作成UIをAPI接続し作成後ハイライト表示に対応

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1693,6 +1694,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1752,6 +1754,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2251,6 +2254,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2591,6 +2595,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3167,6 +3172,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3368,6 +3374,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5131,6 +5138,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -5577,6 +5585,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5586,6 +5595,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5598,6 +5608,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
       "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6325,6 +6336,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6487,6 +6499,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6770,6 +6783,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/(dashboard)/groups/_components/GroupList.tsx
+++ b/frontend/src/app/(dashboard)/groups/_components/GroupList.tsx
@@ -21,6 +21,12 @@ type Props = {
 
   /** アイテム描画差し替え（必要になった時に効く） */
   renderItem?: (group: GroupDTO) => ReactNode
+
+  /**
+   * 作成直後に一覧で「これを作った」が分かるようにハイライトするID
+   * 例: /groups?created=<public_id> の created
+   */
+  highlightedGroupId?: string | null
 }
 
 const DEFAULTS = {
@@ -35,6 +41,11 @@ const styles = {
   list: "mt-2 space-y-3",
   header: "flex items-center justify-between px-2 py-3",
   heading: "text-sm font-semibold text-white/90",
+
+  // ✅ 追加
+  banner:
+    "mb-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/80",
+  highlightWrapper: "rounded-2xl ring-2 ring-emerald-300/30",
 } as const
 
 export function GroupList({
@@ -44,11 +55,18 @@ export function GroupList({
   createHref = DEFAULTS.createHref,
   createLabel = DEFAULTS.createLabel,
   empty,
-  renderItem = defaultRenderItem,
+  renderItem,
+  highlightedGroupId,
 }: Props) {
   if (groups.length === 0) {
     return <>{empty ?? <GroupEmptyState />}</>
   }
+
+  // ✅ 作成直後のバナーは「該当が一覧内に存在する」時だけ出す
+  const createdGroupName =
+    highlightedGroupId ? groups.find((g) => g.public_id === highlightedGroupId)?.name : null
+
+  const render = renderItem ?? makeDefaultRenderItem(highlightedGroupId)
 
   return (
     <section className={styles.section}>
@@ -63,14 +81,35 @@ export function GroupList({
         }
       />
 
-      <div className={styles.list}>{groups.map(renderItem)}</div>
+      {createdGroupName ? (
+        <div className={styles.banner}>「{createdGroupName}」を作成しました</div>
+      ) : null}
+
+      <div className={styles.list}>{groups.map(render)}</div>
     </section>
   )
 }
 
-function defaultRenderItem(group: GroupDTO) {
-  const vm = toGroupListItemVM(group)
-  return <GroupListItem key={vm.id} vm={vm} />
+/**
+ * defaultRenderItem は highlightedGroupId を扱えるように factory 化
+ * - renderItem を差し替えた場合は、呼び出し側で好きな見せ方にできる
+ */
+function makeDefaultRenderItem(highlightedGroupId?: string | null) {
+  return function defaultRenderItem(group: GroupDTO) {
+    const vm = toGroupListItemVM(group)
+    const isHighlighted = highlightedGroupId != null && group.public_id === highlightedGroupId
+
+    const item = <GroupListItem key={vm.id} vm={vm} />
+
+    // ✅ 既存の GroupListItem を壊さず “外側で” ハイライト
+    return isHighlighted ? (
+      <div key={vm.id} className={styles.highlightWrapper}>
+        {item}
+      </div>
+    ) : (
+      item
+    )
+  }
 }
 
 function Header({ title, right }: { title: string; right: ReactNode }) {

--- a/frontend/src/app/(dashboard)/groups/new/_components/GroupCreateForm.tsx
+++ b/frontend/src/app/(dashboard)/groups/new/_components/GroupCreateForm.tsx
@@ -1,13 +1,11 @@
 "use client"
 
-import { useCallback, useState } from "react"
+import { useCallback } from "react"
 import { useForm, type SubmitHandler } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ButtonLink } from "@/components/ui/ButtonLink"
-import {
-  groupCreateSchema,
-  type GroupCreateValues,
-} from "../_schemas/groupCreateSchema"
+import { groupCreateSchema, type GroupCreateValues } from "../_schemas/groupCreateSchema"
+import { useCreateGroupSubmit } from "../_hooks/useCreateGroupSubmit"
 
 const styles = {
   card: "rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_0_0_1px_rgba(255,255,255,0.03)] backdrop-blur",
@@ -16,7 +14,7 @@ const styles = {
   input:
     "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/40 outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-300/20",
   select:
-    "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-300/20",
+    "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/40 focus:ring-emerald-300/20",
   help: "mt-2 text-xs text-white/50",
   error: "mt-2 text-xs text-rose-200",
   actions: "mt-6 flex flex-wrap items-center gap-3",
@@ -33,73 +31,32 @@ const currencyOptions = [
   { value: "EUR", label: "EUR（ユーロ）" },
 ] as const
 
-type CreateGroupPayload = {
-  group: {
-    name: string
-    currency: string
-  }
-}
-
-/**
- * 将来 API 接続する時に差分を小さくするため、payload 生成は関数でまとめる。
- * バックエンドの `group_params`（params.require(:group).permit(:name, :currency)）に合わせる。
- */
-function buildCreateGroupPayload(values: GroupCreateValues): CreateGroupPayload {
-  return {
-    group: {
-      name: values.name,
-      currency: values.currency,
-    },
-  }
-}
-
-/**
- * API未接続のため、送信中状態（isSubmitting）の UI を確認する目的で擬似的に待機する。
- * API接続時は、この sleep を実際の POST リクエストに置き換える。
- */
-function sleep(ms: number) {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms))
-}
-
 export function GroupCreateForm() {
-  const [notice, setNotice] = useState<string>("")
-
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
+    setError,
   } = useForm<GroupCreateValues>({
     resolver: zodResolver(groupCreateSchema),
     mode: "onChange",
-    defaultValues: {
-      name: "",
-      currency: "JPY",
-    },
+    defaultValues: { name: "", currency: "JPY" },
   })
 
-  /**
-   * #13 方針：UIのみ先行（API未接続）
-   * - submit で「ボタンが反応する」「送信中UIが出る」「成功メッセージが出る」を確認する
-   * - 入力値は “保持する” 前提（リセットしない）
-   */
-  const onSubmit: SubmitHandler<GroupCreateValues> = useCallback(async (values) => {
-    setNotice("")
+  const { submit } = useCreateGroupSubmit(setError)
 
-    await sleep(600)
-
-    const payload = buildCreateGroupPayload(values)
-    console.log("[mock submit] POST /api/v1/groups payload:", payload)
-
-    setNotice(
-      `仮: 「${values.name}」を作成しました（currency: ${values.currency} / API未接続）`
-    )
-
-    // 値は保持する（#13の前提）：reset() は呼ばない
-  }, [])
+  const onSubmit: SubmitHandler<GroupCreateValues> = useCallback(
+    async (values) => {
+      await submit(values)
+    },
+    [submit]
+  )
 
   return (
     <section className={styles.card} aria-label="グループ作成フォーム">
       <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        {errors.root?.message ? <div className={styles.notice}>{errors.root.message}</div> : null}
+
         <div className={styles.field}>
           <label className={styles.label} htmlFor="name">
             グループ名 <span className="text-rose-200">*</span>
@@ -111,11 +68,10 @@ export function GroupCreateForm() {
             className={styles.input}
             {...register("name")}
             aria-invalid={Boolean(errors.name)}
+            disabled={isSubmitting}
           />
           <p className={styles.help}>1〜50文字</p>
-          {errors.name?.message ? (
-            <p className={styles.error}>{errors.name.message}</p>
-          ) : null}
+          {errors.name?.message ? <p className={styles.error}>{errors.name.message}</p> : null}
         </div>
 
         <div className={styles.field}>
@@ -127,6 +83,7 @@ export function GroupCreateForm() {
             className={styles.select}
             {...register("currency")}
             aria-invalid={Boolean(errors.currency)}
+            disabled={isSubmitting}
           >
             {currencyOptions.map((o) => (
               <option key={o.value} value={o.value}>
@@ -134,21 +91,13 @@ export function GroupCreateForm() {
               </option>
             ))}
           </select>
-          <p className={styles.help}>
-            未指定の場合、バックエンドではデフォルト（例：JPY）になります
-          </p>
-          {errors.currency?.message ? (
-            <p className={styles.error}>{errors.currency.message}</p>
-          ) : null}
+          <p className={styles.help}>未指定の場合、バックエンドではデフォルト（例：JPY）になります</p>
+          {errors.currency?.message ? <p className={styles.error}>{errors.currency.message}</p> : null}
         </div>
 
         <div className={styles.actions}>
-          <button
-            type="submit"
-            className={styles.submit}
-            disabled={!isValid || isSubmitting}
-          >
-            {isSubmitting ? "作成中..." : "作成する（仮）"}
+          <button type="submit" className={styles.submit} disabled={!isValid || isSubmitting}>
+            {isSubmitting ? "作成中..." : "作成する"}
           </button>
 
           <ButtonLink
@@ -160,13 +109,7 @@ export function GroupCreateForm() {
           >
             一覧に戻る
           </ButtonLink>
-
-          <span className="text-xs text-white/50">
-            ※ API接続は次Issueで実装します
-          </span>
         </div>
-
-        {notice ? <div className={styles.notice}>{notice}</div> : null}
       </form>
     </section>
   )

--- a/frontend/src/app/(dashboard)/groups/new/_hooks/useCreateGroupSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/new/_hooks/useCreateGroupSubmit.ts
@@ -1,0 +1,95 @@
+"use client"
+
+import { useCallback } from "react"
+import { useRouter } from "next/navigation"
+import type { UseFormSetError } from "react-hook-form"
+import { createGroup } from "@/lib/api/groups"
+import type { ApiError } from "@/lib/api/problemDetailsError"
+import { useRequireAuth } from "@/hooks/useRequireAuth"
+import type { GroupCreateValues } from "../_schemas/groupCreateSchema"
+
+type CreateGroupPayload = {
+  group: {
+    name: string
+    currency: string
+  }
+}
+
+function buildCreateGroupPayload(values: GroupCreateValues): CreateGroupPayload {
+  return {
+    group: {
+      name: values.name,
+      currency: values.currency,
+    },
+  }
+}
+
+function getFirstErrorMessage(v: unknown): string | null {
+  if (!v) return null
+  if (Array.isArray(v)) return v.length > 0 ? String(v[0]) : null
+  return String(v)
+}
+
+export function useCreateGroupSubmit(setError: UseFormSetError<GroupCreateValues>) {
+  const router = useRouter()
+  const { requireToken } = useRequireAuth()
+
+  const submit = useCallback(
+    async (values: GroupCreateValues): Promise<void> => {
+      const token = await requireToken("/groups/new")
+      if (!token) {
+        setError("root", {
+          type: "server",
+          message: "ログインが必要です。",
+        })
+        return
+      }
+
+      try {
+        const payload = buildCreateGroupPayload(values)
+
+        const res = await createGroup(payload, { token })
+        const createdId = res.group.public_id
+
+        router.push(`/groups?created=${encodeURIComponent(createdId)}`)
+        router.refresh()
+      } catch (e) {
+        const err = e as ApiError
+
+        if (err.code === "UNAUTHORIZED") {
+          setError("root", {
+            type: "server",
+            message: "ログインが必要です。",
+          })
+          return
+        }
+
+        if (err.status === 422 && err.problem?.errors) {
+          const pe = err.problem.errors as Record<string, unknown>
+
+          const nameMsg = getFirstErrorMessage(pe["name"])
+          const currencyMsg = getFirstErrorMessage(pe["currency"])
+
+          if (nameMsg) setError("name", { type: "server", message: nameMsg })
+          if (currencyMsg) setError("currency", { type: "server", message: currencyMsg })
+
+          if (!nameMsg && !currencyMsg) {
+            setError("root", {
+              type: "server",
+              message: err.problem.detail ?? "入力内容を確認してください。",
+            })
+          }
+          return
+        }
+
+        setError("root", {
+          type: "server",
+          message: err.problem?.detail ?? "作成に失敗しました。",
+        })
+      }
+    },
+    [requireToken, router, setError]
+  )
+
+  return { submit }
+}

--- a/frontend/src/app/(dashboard)/groups/new/_hooks/useCreateGroupSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/new/_hooks/useCreateGroupSubmit.ts
@@ -4,16 +4,10 @@ import { useCallback } from "react"
 import { useRouter } from "next/navigation"
 import type { UseFormSetError } from "react-hook-form"
 import { createGroup } from "@/lib/api/groups"
+import type { CreateGroupPayload } from "@/lib/api/groups"
 import type { ApiError } from "@/lib/api/problemDetailsError"
 import { useRequireAuth } from "@/hooks/useRequireAuth"
 import type { GroupCreateValues } from "../_schemas/groupCreateSchema"
-
-type CreateGroupPayload = {
-  group: {
-    name: string
-    currency: string
-  }
-}
 
 function buildCreateGroupPayload(values: GroupCreateValues): CreateGroupPayload {
   return {
@@ -38,16 +32,12 @@ export function useCreateGroupSubmit(setError: UseFormSetError<GroupCreateValues
     async (values: GroupCreateValues): Promise<void> => {
       const token = await requireToken("/groups/new")
       if (!token) {
-        setError("root", {
-          type: "server",
-          message: "ログインが必要です。",
-        })
+        setError("root", { type: "server", message: "ログインが必要です。" })
         return
       }
 
       try {
         const payload = buildCreateGroupPayload(values)
-
         const res = await createGroup(payload, { token })
         const createdId = res.group.public_id
 
@@ -57,10 +47,7 @@ export function useCreateGroupSubmit(setError: UseFormSetError<GroupCreateValues
         const err = e as ApiError
 
         if (err.code === "UNAUTHORIZED") {
-          setError("root", {
-            type: "server",
-            message: "ログインが必要です。",
-          })
+          setError("root", { type: "server", message: "ログインが必要です。" })
           return
         }
 

--- a/frontend/src/app/(dashboard)/groups/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/page.tsx
@@ -18,19 +18,24 @@ export default function GroupsPage() {
     return Math.floor(n)
   }, [searchParams])
 
+  // ✅ 追加：作成直後のハイライト用（/groups?created=<public_id>）
+  const created = useMemo(() => searchParams.get("created"), [searchParams])
+
   const { groups, meta, isLoading, error } = useGroups({ page })
 
+  // ✅ created は “作成直後の一回だけ” が自然なので、ページ移動時は消す
   const goToPage = useCallback(
     (p: number) => {
-      router.push(`/groups?page=${p}`, { scroll: false })
+      const sp = new URLSearchParams(searchParams.toString())
+      sp.set("page", String(p))
+      sp.delete("created")
+      router.push(`/groups?${sp.toString()}`, { scroll: false })
     },
-    [router]
+    [router, searchParams]
   )
 
-  const isEmpty =
-    !isLoading && !error && Array.isArray(groups) && groups.length === 0
-  const hasGroups =
-    !isLoading && !error && Array.isArray(groups) && groups.length > 0
+  const isEmpty = !isLoading && !error && Array.isArray(groups) && groups.length === 0
+  const hasGroups = !isLoading && !error && Array.isArray(groups) && groups.length > 0
 
   const totalPages = meta?.total_pages ?? 1
   const currentPage = meta?.page ?? page
@@ -53,9 +58,7 @@ export default function GroupsPage() {
           <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
             <p className="text-sm font-semibold">取得に失敗しました</p>
             <p className="mt-2 text-sm text-white/70">
-              {error.message === "UNAUTHORIZED"
-                ? "ログインが必要です。"
-                : "時間をおいて再度お試しください。"}
+              {error.message === "UNAUTHORIZED" ? "ログインが必要です。" : "時間をおいて再度お試しください。"}
             </p>
           </div>
         )}
@@ -64,14 +67,11 @@ export default function GroupsPage() {
 
         {hasGroups && (
           <>
-            <GroupList groups={groups} />
+            {/* ✅ 追加：created を GroupList に渡す */}
+            <GroupList groups={groups} highlightedGroupId={created} />
 
             {showPagination && (
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                onChange={goToPage}
-              />
+              <Pagination currentPage={currentPage} totalPages={totalPages} onChange={goToPage} />
             )}
           </>
         )}

--- a/frontend/src/app/(dashboard)/groups/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/page.tsx
@@ -18,12 +18,12 @@ export default function GroupsPage() {
     return Math.floor(n)
   }, [searchParams])
 
-  // ✅ 追加：作成直後のハイライト用（/groups?created=<public_id>）
-  const created = useMemo(() => searchParams.get("created"), [searchParams])
+  // 作成直後のハイライト用（/groups?created=<public_id>）
+  const created = searchParams.get("created")
 
   const { groups, meta, isLoading, error } = useGroups({ page })
 
-  // ✅ created は “作成直後の一回だけ” が自然なので、ページ移動時は消す
+  // created は作成直後の一回だけが自然なので、ページ移動時は消す
   const goToPage = useCallback(
     (p: number) => {
       const sp = new URLSearchParams(searchParams.toString())
@@ -58,7 +58,9 @@ export default function GroupsPage() {
           <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
             <p className="text-sm font-semibold">取得に失敗しました</p>
             <p className="mt-2 text-sm text-white/70">
-              {error.message === "UNAUTHORIZED" ? "ログインが必要です。" : "時間をおいて再度お試しください。"}
+              {error.message === "UNAUTHORIZED"
+                ? "ログインが必要です。"
+                : "時間をおいて再度お試しください。"}
             </p>
           </div>
         )}
@@ -67,7 +69,6 @@ export default function GroupsPage() {
 
         {hasGroups && (
           <>
-            {/* ✅ 追加：created を GroupList に渡す */}
             <GroupList groups={groups} highlightedGroupId={created} />
 
             {showPagination && (

--- a/frontend/src/hooks/useRequireAuth.ts
+++ b/frontend/src/hooks/useRequireAuth.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { useCallback } from "react"
+import { useAuth } from "@clerk/nextjs"
+import { useRouter } from "next/navigation"
+
+function toSignInUrl(nextPath: string) {
+  return `/sign-in?redirect_url=${encodeURIComponent(nextPath)}`
+}
+
+export function useRequireAuth() {
+  const router = useRouter()
+  const { getToken } = useAuth()
+
+  const requireToken = useCallback(
+    async (nextPath: string): Promise<string | null> => {
+      const token = await getToken()
+      if (token) return token
+
+      router.push(toSignInUrl(nextPath))
+      return null
+    },
+    [getToken, router]
+  )
+
+  return { requireToken }
+}

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -51,7 +51,6 @@ async function requestJson<T>(path: string, options: RequestOptions = {}): Promi
   const res = await fetch(buildUrl(path, baseUrl), {
     ...init,
     headers,
-    credentials: init.credentials ?? "include",
     cache: init.cache ?? "no-store",
   })
 

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,0 +1,122 @@
+import { toApiError } from "@/lib/api/problemDetailsError"
+
+export type Group = {
+  public_id: string
+  name: string
+  currency: string
+  created_at?: string
+  updated_at?: string
+}
+
+export type CreateGroupInput = {
+  name: string
+}
+
+export type CreateGroupResponse = {
+  group: Group
+}
+
+export type GroupListItem = {
+  public_id: string
+  name: string
+  currency: string
+  updated_at: string
+  member_count: number
+}
+
+export type PaginationMeta = {
+  page: number
+  per_page: number
+  total_count?: number | null
+  total_pages?: number | null
+}
+
+export type GroupListResponse = {
+  groups: GroupListItem[]
+  meta: PaginationMeta
+}
+
+const DEFAULT_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:3000"
+
+function normalizeBaseUrl(baseUrl: string) {
+  return baseUrl.replace(/\/+$/, "")
+}
+
+function buildUrl(path: string, baseUrl = DEFAULT_BASE_URL) {
+  const base = normalizeBaseUrl(baseUrl)
+  const p = path.startsWith("/") ? path : `/${path}`
+  return `${base}${p}`
+}
+
+type RequestOptions = RequestInit & {
+  token?: string
+  baseUrl?: string
+}
+
+async function requestJson<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { token, baseUrl, ...init } = options
+
+  const headers = new Headers(options.headers)
+  headers.set("Accept", "application/json")
+
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
+  }
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`)
+  }
+
+  const res = await fetch(buildUrl(path, baseUrl), {
+    ...init,
+    headers,
+    credentials: init.credentials ?? "include",
+    cache: init.cache ?? "no-store",
+  })
+
+  if (!res.ok) {
+    throw await toApiError(res)
+  }
+
+  return (await res.json()) as T
+}
+
+/**
+ * POST /api/v1/groups
+ */
+export type CreateGroupPayload = {
+  group: {
+    name: string
+    currency: string
+  }
+}
+
+export async function createGroup(
+  payload: CreateGroupPayload,
+  opts: { token?: string; baseUrl?: string } = {}
+) {
+  return requestJson<CreateGroupResponse>("/api/v1/groups", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    token: opts.token,
+    baseUrl: opts.baseUrl,
+  })
+}
+
+/**
+ * GET /api/v1/groups?page=1
+ */
+export async function fetchGroups(
+  params: { page?: number } = {},
+  opts: { token?: string; baseUrl?: string } = {}
+): Promise<GroupListResponse> {
+  const search = new URLSearchParams()
+  if (params.page) search.set("page", String(params.page))
+  const path = search.toString() ? `/api/v1/groups?${search.toString()}` : "/api/v1/groups"
+
+  return requestJson<GroupListResponse>(path, {
+    method: "GET",
+    token: opts.token,
+    baseUrl: opts.baseUrl,
+  })
+}

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,4 +1,5 @@
 import { toApiError } from "@/lib/api/problemDetailsError"
+import type { GroupListResponse } from "@/types/groups"
 
 export type Group = {
   public_id: string
@@ -14,26 +15,6 @@ export type CreateGroupInput = {
 
 export type CreateGroupResponse = {
   group: Group
-}
-
-export type GroupListItem = {
-  public_id: string
-  name: string
-  currency: string
-  updated_at: string
-  member_count: number
-}
-
-export type PaginationMeta = {
-  page: number
-  per_page: number
-  total_count?: number | null
-  total_pages?: number | null
-}
-
-export type GroupListResponse = {
-  groups: GroupListItem[]
-  meta: PaginationMeta
 }
 
 const DEFAULT_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:3000"

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -9,10 +9,6 @@ export type Group = {
   updated_at?: string
 }
 
-export type CreateGroupInput = {
-  name: string
-}
-
 export type CreateGroupResponse = {
   group: Group
 }


### PR DESCRIPTION
## 概要

グループ作成UIをモック実装からAPI接続に切り替えました。  
作成成功時は一覧画面へ遷移し、作成直後のグループをバナー表示＋ハイライトします。

---

## 変更内容

### 1. グループ作成フォームのAPI接続
- モック送信処理を削除
- `useCreateGroupSubmit` を導入し、API呼び出しをhookに分離
- 送信中はフォーム入力とボタンをdisable

### 2. エラーハンドリング整理
- 401: 未認証時はrootエラー表示
- 422: フィールド単位でエラーメッセージを表示
- その他: rootエラーにフォールバック

### 3. 作成直後のUX改善
- `/groups?created=<public_id>` を付与して一覧へ遷移
- 一覧側で該当グループを検出し、バナー表示＋ハイライト
- ページ移動時は `created` クエリを削除

### 4. 責務分離
- 認証取得処理を `useRequireAuth` に分離
- groups API呼び出しを `lib/api/groups.ts` に集約

---

## 意図

- フォームコンポーネントをUI責務に限定
- API通信・認証・エラー整形はhook側へ集約
- 一覧側で成功通知を出すことで遷移前noticeを削除

---

## 確認観点

- グループ作成成功後、一覧に遷移すること
- 作成したグループがバナー表示＋ハイライトされること
- 422時にフィールドエラーが正しく表示されること
- 未認証時に適切にエラー表示されること