### PR TITLE
feature/issue21-invite-token-api 招待トークンからグループ情報を取得するAPIを実装

### DIFF
--- a/backend/app/controllers/api/v1/invites_controller.rb
+++ b/backend/app/controllers/api/v1/invites_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class InvitesController < ApplicationController
+      skip_before_action :authenticate_with_clerk!
+
+      def show
+        group = Group.find_by!(invite_token: params[:invite_token])
+
+        render json: {
+          group: {
+            id: group.public_id,
+            name: group.name,
+            members_count: group.members.where(active: true).count
+          }
+        }
+      rescue ActiveRecord::RecordNotFound
+        render_not_found(reason: "invalid_invite_token", detail: "invite_token is invalid")
+      end
+    end
+  end
+end

--- a/backend/app/controllers/concerns/problem_renderable.rb
+++ b/backend/app/controllers/concerns/problem_renderable.rb
@@ -28,6 +28,22 @@ module ProblemRenderable
     render json: payload, status: status, content_type: PROBLEM_JSON
   end
 
+  # 404 の detail を指定して返す（共通化）
+  #
+  # NOTE:
+  # - detail は OpenAPI 上 required 前提のため、呼び出し側で渡す運用を推奨
+  def render_not_found(reason: "not_found", detail: nil, type: "about:blank", instance: nil, **ext)
+    render_problem(
+      title: "Not Found",
+      status: 404,
+      reason: reason,
+      detail: detail,
+      type: type,
+      instance: instance,
+      **ext
+    )
+  end
+
   # 401 の detail を reason から解決して埋める（spec の期待に合わせる）
   def render_unauthorized(reason, detail: nil, type: "about:blank", instance: nil, **ext)
     resolved_detail =

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get "me", to: "me#show"
       resources :groups, only: %i[index create]
+      resources :invites, param: :invite_token, only: [:show]
     end
   end
 end

--- a/backend/spec/requests/api/v1/invites_spec.rb
+++ b/backend/spec/requests/api/v1/invites_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Invites API", type: :request do
+  describe "GET /api/v1/invites/:invite_token" do
+    let(:invite_token) { "token_123" }
+    let(:owner) { create(:user) }
+    let!(:group) { create(:group, invite_token: invite_token, name: "大阪旅行") }
+
+    before do
+      create(:member, group: group, user: owner, role: "OWNER", active: true, joined_at: Time.current)
+    end
+
+    context "正常系" do
+      it "招待トークンでグループ情報を取得できる" do
+        get "/api/v1/invites/#{invite_token}"
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+
+        expect(body).to have_key("group")
+        expect(body.dig("group", "id")).to eq(group.public_id)
+        expect(body.dig("group", "name")).to eq("大阪旅行")
+        expect(body.dig("group", "members_count")).to eq(1)
+      end
+    end
+
+    context "異常系" do
+      it "無効トークンで404（RFC9457）を返す" do
+        get "/api/v1/invites/invalid_token"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.media_type).to eq("application/problem+json")
+
+        body = response.parsed_body
+        expect(body["title"]).to eq("Not Found")
+        expect(body["status"]).to eq(404)
+        expect(body["reason"]).to eq("invalid_invite_token")
+        expect(body["detail"]).to eq("invite_token is invalid")
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/invites_spec.rb
+++ b/backend/spec/requests/api/v1/invites_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 
 RSpec.describe "Invites API", type: :request do
   describe "GET /api/v1/invites/:invite_token" do
-    let(:invite_token) { "token_123" }
-    let(:owner) { create(:user) }
-    let!(:group) { create(:group, invite_token: invite_token, name: "大阪旅行") }
+    let!(:invite_token) { "token_123" }
 
-    before do
+    let!(:owner) { create(:user) }
+    let!(:group) { create(:group, invite_token: invite_token, name: "大阪旅行") }
+    let!(:member) do
       create(:member, group: group, user: owner, role: "OWNER", active: true, joined_at: Time.current)
     end
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -405,6 +405,25 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/invites/{invite_token}:
+    get:
+      operationId: getInvite
+      tags:
+        - Groups
+      summary: 招待トークンからグループ情報を取得（招待ページ表示用）
+      security: [] # 招待ページは未ログインでも参照できる
+      parameters:
+        - $ref: "#/components/parameters/InviteToken"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InviteGroupResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/v1/groups/{groupId}/expenses/{expenseId}/attachments:
     post:
       operationId: createAttachment
@@ -548,6 +567,14 @@ components:
       schema:
         type: string
 
+    InviteToken:
+      name: invite_token
+      in: path
+      required: true
+      schema:
+        type: string
+      description: 招待トークン
+
   responses:
     BadRequest:
       description: Bad Request
@@ -679,6 +706,7 @@ components:
           nullable: true
           default: true
         theme_mode:
+          type: string
           allOf:
             - $ref: "#/components/schemas/ThemeMode"
           nullable: true
@@ -854,6 +882,32 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Member"
+
+    InviteGroupResponse:
+      type: object
+      required:
+        - group
+      properties:
+        group:
+          $ref: "#/components/schemas/InviteGroup"
+
+    InviteGroup:
+      type: object
+      required:
+        - id
+        - name
+        - members_count
+      properties:
+        id:
+          type: string
+          description: グループの public_id
+          example: MyjusiApaCFaYhQVSEAxzjs6Bw
+        name:
+          type: string
+          example: 大阪旅行
+        members_count:
+          type: integer
+          example: 4
 
     Expense:
       type: object
@@ -1137,6 +1191,7 @@ components:
           type: string
         group_id:
           type: string
+          nullable: true
         from_id:
           type: string
         to_id:


### PR DESCRIPTION
## 概要

招待トークン（invite_token）からグループ情報を取得するAPIを実装しました。

QRコード招待や招待リンクからアクセスされた際に、
招待ページに表示するグループ情報を取得するためのエンドポイントです。

GET /api/v1/invites/:invite_token

招待ページ用のため、未ログイン状態でもアクセス可能にしています。

---

## 背景

Splittoではグループ参加方法として以下を採用しています。

- QRコード招待
- 招待リンク

例

/invite/:invite_token

このURLからグループ情報を取得するAPIが必要となるため実装しました。

---

## 変更内容

### Controller

InvitesController を追加しました。

処理内容

- invite_token で Group を検索
- 見つからない場合は 404 を返す
- RFC9457（Problem Details）形式でエラーを返す
- 招待ページ用のため認証をスキップ

レスポンス例

```json
{
  "group": {
    "id": "grp_xxxxx",
    "name": "大阪旅行",
    "members_count": 4
  }
}
```
### Routing
```ruby
resources :invites, param: :invite_token, only: [:show]
```
### Error Response
404エラーは ProblemRenderable の共通メソッドを利用しています。
```
render_not_found(
  reason: "invalid_invite_token",
  detail: "invite_token is invalid"
)
```

### RSpec

Request Spec を追加しました。

spec/requests/api/v1/invites_spec.rb

テスト内容

正常系
- 招待トークンでグループ情報を取得できる
- members_count が active メンバー数で返る

異常系
- 無効トークンの場合 404
- RFC9457（application/problem+json）形式で返る

### OpenAPI

以下を追加しました。

`GET /api/v1/invites/{invite_token}`

追加スキーマ
- InviteToken
- nviteGroupResponse
- InviteGroup
OpenAPI lint も確認済みです。

`redocly lint openapi/openapi.yaml`

### Acceptance Criteria
- [x] 正常系 spec が通る
- [x] 無効トークンで 404
- [x]  RFC9457 Problem Details 形式
- [x] OpenAPI と整合
- [x] 未ログイン状態でもアクセス可能

