### PR TITLE
feat: 同じグループになったことがあるユーザー取得APIを実装 (#31)

### DIFF
--- a/backend/app/controllers/api/v1/me/shared_group_users_controller.rb
+++ b/backend/app/controllers/api/v1/me/shared_group_users_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Me
+      class SharedGroupUsersController < ApplicationController
+        def index
+          render json: { shared_group_users: serialized_shared_group_users }, status: :ok
+        end
+
+        private
+
+        def shared_group_users
+          ::Me::SharedGroupUsersQuery.new(current_user).call
+        end
+
+        def serialized_shared_group_users
+          shared_group_users.map do |shared_group_user|
+            serialize_shared_group_user(shared_group_user)
+          end
+        end
+
+        def serialize_shared_group_user(shared_group_user)
+          {
+            user_id: shared_group_user.public_user_id,
+            last_together_at: shared_group_user.last_together_at.iso8601
+          }
+        end
+      end
+    end
+  end
+end

--- a/backend/app/queries/me/shared_group_users_query.rb
+++ b/backend/app/queries/me/shared_group_users_query.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Me
+  class SharedGroupUsersQuery
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      shared_group_members
+        .select(*select_columns)
+        .group(*group_columns)
+        .order(last_together_at_desc)
+        .order(users_public_id_asc)
+    end
+
+    private
+
+    attr_reader :user
+
+    def shared_group_members
+      Member
+        .joins(:user)
+        .where(group_id: joined_group_ids)
+        .where.not(user_id: user.id)
+    end
+
+    def joined_group_ids
+      user.members.select(:group_id)
+    end
+
+    def select_columns
+      [
+        "users.public_id AS public_user_id",
+        "MAX(members.updated_at) AS last_together_at"
+      ]
+    end
+
+    def group_columns
+      [
+        "members.user_id",
+        "users.public_id"
+      ]
+    end
+
+    def last_together_at_desc
+      Arel.sql("MAX(members.updated_at) DESC")
+    end
+
+    def users_public_id_asc
+      "users.public_id ASC"
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "me", to: "me#show"
+      get "me/shared_group_users", to: "me/shared_group_users#index"
 
       resources :groups, only: %i[index create]
       resources :invites, param: :invite_token, only: [:show]

--- a/backend/spec/queries/me/shared_group_users_query_spec.rb
+++ b/backend/spec/queries/me/shared_group_users_query_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Me::SharedGroupUsersQuery do
+  describe "#call" do
+    context "同じグループに所属したユーザーがいるとき" do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group) }
+      let!(:other_group) { create(:group) }
+      let!(:other_user) { create(:user) }
+      let!(:unrelated_user) { create(:user) }
+
+      let!(:my_member) do
+        create(
+          :member,
+          user: user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 09:00:00")
+        )
+      end
+
+      let!(:other_member) do
+        create(
+          :member,
+          user: other_user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
+      let!(:unrelated_member) do
+        create(
+          :member,
+          user: unrelated_user,
+          group: other_group,
+          updated_at: Time.zone.parse("2026-03-06 10:00:00")
+        )
+      end
+
+      it "同じグループに所属したユーザーを返す" do
+        result = described_class.new(user).call
+
+        expect(result.map(&:public_user_id)).to eq([other_user.public_id])
+      end
+    end
+
+    context "自分自身が同じグループに所属しているとき" do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group) }
+      let!(:other_user) { create(:user) }
+
+      let!(:my_member) do
+        create(
+          :member,
+          user: user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 09:00:00")
+        )
+      end
+
+      let!(:other_member) do
+        create(
+          :member,
+          user: other_user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
+      it "自分自身を含まない" do
+        result = described_class.new(user).call
+
+        expect(result.map(&:public_user_id)).not_to include(user.public_id)
+      end
+    end
+
+    context "同じユーザーが複数の共有グループに所属しているとき" do
+      let!(:user) { create(:user) }
+      let!(:group_a) { create(:group) }
+      let!(:group_b) { create(:group) }
+      let!(:other_user) { create(:user) }
+
+      let!(:my_member_in_group_a) do
+        create(
+          :member,
+          user: user,
+          group: group_a,
+          updated_at: Time.zone.parse("2026-03-01 09:00:00")
+        )
+      end
+
+      let!(:my_member_in_group_b) do
+        create(
+          :member,
+          user: user,
+          group: group_b,
+          updated_at: Time.zone.parse("2026-03-02 09:00:00")
+        )
+      end
+
+      let!(:other_member_in_group_a) do
+        create(
+          :member,
+          user: other_user,
+          group: group_a,
+          updated_at: Time.zone.parse("2026-03-03 10:00:00")
+        )
+      end
+
+      let!(:other_member_in_group_b) do
+        create(
+          :member,
+          user: other_user,
+          group: group_b,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
+      it "同じユーザーを1件に集約する" do
+        result = described_class.new(user).call
+
+        expect(result.to_a.size).to eq(1)
+        expect(result.first.public_user_id).to eq(other_user.public_id)
+      end
+
+      it "last_together_at に最も新しい updated_at を返す" do
+        result = described_class.new(user).call
+
+        expect(result.first.last_together_at.iso8601).to eq(
+          other_member_in_group_b.updated_at.iso8601
+        )
+      end
+    end
+
+    context "同じグループに所属した他ユーザーがいないとき" do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group) }
+
+      let!(:my_member) do
+        create(
+          :member,
+          user: user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 09:00:00")
+        )
+      end
+
+      it "空の結果を返す" do
+        result = described_class.new(user).call
+
+        expect(result).to be_empty
+      end
+    end
+
+    context "last_together_at が異なるユーザーがいるとき" do
+      let!(:user) { create(:user) }
+      let!(:group_a) { create(:group) }
+      let!(:group_b) { create(:group) }
+      let!(:older_user) { create(:user) }
+      let!(:newer_user) { create(:user) }
+
+      let!(:my_member_in_group_a) do
+        create(
+          :member,
+          user: user,
+          group: group_a,
+          updated_at: Time.zone.parse("2026-03-01 09:00:00")
+        )
+      end
+
+      let!(:my_member_in_group_b) do
+        create(
+          :member,
+          user: user,
+          group: group_b,
+          updated_at: Time.zone.parse("2026-03-02 09:00:00")
+        )
+      end
+
+      let!(:older_user_member) do
+        create(
+          :member,
+          user: older_user,
+          group: group_a,
+          updated_at: Time.zone.parse("2026-03-03 10:00:00")
+        )
+      end
+
+      let!(:newer_user_member) do
+        create(
+          :member,
+          user: newer_user,
+          group: group_b,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
+      it "last_together_at の降順で返す" do
+        result = described_class.new(user).call
+
+        expect(result.map(&:public_user_id)).to eq(
+          [newer_user.public_id, older_user.public_id]
+        )
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/me/shared_group_users_spec.rb
+++ b/backend/spec/requests/api/v1/me/shared_group_users_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/me/shared_group_users", type: :request do
+  describe "GET /api/v1/me/shared_group_users" do
+    context "認証成功のとき" do
+      let!(:external_uid) { "clerk_user_123" }
+      let!(:token) { "test-token" }
+      let!(:headers) { { "Authorization" => "Bearer #{token}" } }
+      let!(:user) { create(:user, external_uid: external_uid) }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => external_uid }
+        )
+      end
+
+      context "同じグループに所属したユーザーがいるとき" do
+        let!(:group) { create(:group) }
+        let!(:other_group) { create(:group) }
+        let!(:other_user) { create(:user) }
+        let!(:unrelated_user) { create(:user) }
+
+        let!(:my_member) do
+          create(
+            :member,
+            user: user,
+            group: group,
+            updated_at: Time.zone.parse("2026-03-05 10:00:00")
+          )
+        end
+
+        let!(:other_member) do
+          create(
+            :member,
+            user: other_user,
+            group: group,
+            updated_at: Time.zone.parse("2026-03-05 10:00:00")
+          )
+        end
+
+        let!(:unrelated_member) do
+          create(
+            :member,
+            user: unrelated_user,
+            group: other_group,
+            updated_at: Time.zone.parse("2026-03-06 10:00:00")
+          )
+        end
+
+        it "同じグループに所属したユーザーが取得できる" do
+          get "/api/v1/me/shared_group_users", headers: headers
+
+          expect(response).to have_http_status(:ok)
+          assert_response_schema_confirm(200)
+
+          body = JSON.parse(response.body)
+
+          expect(body["shared_group_users"]).to eq(
+            [
+              {
+                "user_id" => other_user.public_id,
+                "last_together_at" => other_member.updated_at.iso8601
+              }
+            ]
+          )
+        end
+      end
+
+      context "同じグループに所属した他ユーザーがいないとき" do
+        let!(:group) { create(:group) }
+
+        let!(:my_member) do
+          create(
+            :member,
+            user: user,
+            group: group,
+            updated_at: Time.zone.parse("2026-03-05 10:00:00")
+          )
+        end
+
+        it "空配列が返る" do
+          get "/api/v1/me/shared_group_users", headers: headers
+
+          expect(response).to have_http_status(:ok)
+          assert_response_schema_confirm(200)
+
+          body = JSON.parse(response.body)
+
+          expect(body["shared_group_users"]).to eq([])
+        end
+      end
+
+      context "自分自身を除外するとき" do
+        let!(:group) { create(:group) }
+        let!(:other_user) { create(:user) }
+
+        let!(:my_member) do
+          create(
+            :member,
+            user: user,
+            group: group,
+            updated_at: Time.zone.parse("2026-03-05 10:00:00")
+          )
+        end
+
+        let!(:other_member) do
+          create(
+            :member,
+            user: other_user,
+            group: group,
+            updated_at: Time.zone.parse("2026-03-05 10:00:00")
+          )
+        end
+
+        it "自分自身は含まれない" do
+          get "/api/v1/me/shared_group_users", headers: headers
+
+          expect(response).to have_http_status(:ok)
+          assert_response_schema_confirm(200)
+
+          body = JSON.parse(response.body)
+          user_ids = body["shared_group_users"].map { |shared_group_user| shared_group_user["user_id"] }
+
+          expect(user_ids).not_to include(user.public_id)
+        end
+      end
+    end
+
+    context "認証失敗のとき" do
+      context "Authorizationヘッダーがないとき" do
+        it "401を返す" do
+          get "/api/v1/me/shared_group_users"
+
+          expect(response).to have_http_status(:unauthorized)
+          assert_response_schema_confirm(401)
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/me/shared_group_users_spec.rb
+++ b/backend/spec/requests/api/v1/me/shared_group_users_spec.rb
@@ -10,130 +10,48 @@ RSpec.describe "GET /api/v1/me/shared_group_users", type: :request do
       let!(:headers) { { "Authorization" => "Bearer #{token}" } }
       let!(:user) { create(:user, external_uid: external_uid) }
 
+      let!(:group) { create(:group) }
+      let!(:other_user) { create(:user) }
+
+      let!(:my_member) do
+        create(
+          :member,
+          user: user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
+      let!(:other_member) do
+        create(
+          :member,
+          user: other_user,
+          group: group,
+          updated_at: Time.zone.parse("2026-03-05 10:00:00")
+        )
+      end
+
       before do
         allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
           { "sub" => external_uid }
         )
       end
 
-      context "同じグループに所属したユーザーがいるとき" do
-        let!(:group) { create(:group) }
-        let!(:other_group) { create(:group) }
-        let!(:other_user) { create(:user) }
-        let!(:unrelated_user) { create(:user) }
+      it "200を返し、レスポンスがOpenAPIスキーマに一致する" do
+        get "/api/v1/me/shared_group_users", headers: headers
 
-        let!(:my_member) do
-          create(
-            :member,
-            user: user,
-            group: group,
-            updated_at: Time.zone.parse("2026-03-05 10:00:00")
-          )
-        end
-
-        let!(:other_member) do
-          create(
-            :member,
-            user: other_user,
-            group: group,
-            updated_at: Time.zone.parse("2026-03-05 10:00:00")
-          )
-        end
-
-        let!(:unrelated_member) do
-          create(
-            :member,
-            user: unrelated_user,
-            group: other_group,
-            updated_at: Time.zone.parse("2026-03-06 10:00:00")
-          )
-        end
-
-        it "同じグループに所属したユーザーが取得できる" do
-          get "/api/v1/me/shared_group_users", headers: headers
-
-          expect(response).to have_http_status(:ok)
-          assert_response_schema_confirm(200)
-
-          body = JSON.parse(response.body)
-
-          expect(body["shared_group_users"]).to eq(
-            [
-              {
-                "user_id" => other_user.public_id,
-                "last_together_at" => other_member.updated_at.iso8601
-              }
-            ]
-          )
-        end
-      end
-
-      context "同じグループに所属した他ユーザーがいないとき" do
-        let!(:group) { create(:group) }
-
-        let!(:my_member) do
-          create(
-            :member,
-            user: user,
-            group: group,
-            updated_at: Time.zone.parse("2026-03-05 10:00:00")
-          )
-        end
-
-        it "空配列が返る" do
-          get "/api/v1/me/shared_group_users", headers: headers
-
-          expect(response).to have_http_status(:ok)
-          assert_response_schema_confirm(200)
-
-          body = JSON.parse(response.body)
-
-          expect(body["shared_group_users"]).to eq([])
-        end
-      end
-
-      context "自分自身を除外するとき" do
-        let!(:group) { create(:group) }
-        let!(:other_user) { create(:user) }
-
-        let!(:my_member) do
-          create(
-            :member,
-            user: user,
-            group: group,
-            updated_at: Time.zone.parse("2026-03-05 10:00:00")
-          )
-        end
-
-        let!(:other_member) do
-          create(
-            :member,
-            user: other_user,
-            group: group,
-            updated_at: Time.zone.parse("2026-03-05 10:00:00")
-          )
-        end
-
-        it "自分自身は含まれない" do
-          get "/api/v1/me/shared_group_users", headers: headers
-
-          expect(response).to have_http_status(:ok)
-          assert_response_schema_confirm(200)
-
-          body = JSON.parse(response.body)
-          user_ids = body["shared_group_users"].map { |shared_group_user| shared_group_user["user_id"] }
-
-          expect(user_ids).not_to include(user.public_id)
-        end
+        expect(response).to have_http_status(:ok)
+        assert_response_schema_confirm(200)
       end
     end
 
     context "認証失敗のとき" do
       context "Authorizationヘッダーがないとき" do
-        it "401を返す" do
+        it "401を返し、レスポンスがOpenAPIスキーマに一致する" do
           get "/api/v1/me/shared_group_users"
 
           expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
           assert_response_schema_confirm(401)
         end
       end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -16,6 +16,8 @@ servers:
 tags:
   - name: Auth
     description: 認証・ログインユーザー関連
+  - name: Me
+    description: ログインユーザー本人向け機能
   - name: Users
     description: ユーザー情報
   - name: Groups
@@ -48,6 +50,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v1/me/shared_group_users:
+    get:
+      operationId: getSharedGroupUsers
+      tags:
+        - Me
+      summary: 同じグループになったことがあるユーザー一覧取得
+      description: >
+        ログインユーザーと同じグループに所属したことがある他ユーザー一覧を取得します。
+        自分自身は含まれません。
+        last_together_at の降順で返します。
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SharedGroupUsersResponse"
+              examples:
+                default:
+                  summary: shared group users response
+                  value:
+                    shared_group_users:
+                      - user_id: usr_01HABCDEFG1234567890XYZ
+                        last_together_at: "2026-03-05T10:00:00Z"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -411,7 +442,7 @@ paths:
       tags:
         - Groups
       summary: 招待トークンからグループ情報を取得（招待ページ表示用）
-      security: [] # 招待ページは未ログインでも参照できる
+      security: []
       parameters:
         - $ref: "#/components/parameters/InviteToken"
       responses:
@@ -679,6 +710,33 @@ components:
             type: array
             items:
               type: string
+
+    SharedGroupUsersResponse:
+      type: object
+      required:
+        - shared_group_users
+      properties:
+        shared_group_users:
+          type: array
+          description: 同じグループになったことがある他ユーザー一覧
+          items:
+            $ref: "#/components/schemas/SharedGroupUser"
+
+    SharedGroupUser:
+      type: object
+      required:
+        - user_id
+        - last_together_at
+      properties:
+        user_id:
+          type: string
+          description: ユーザーの公開ID
+          example: usr_01HABCDEFG1234567890XYZ
+        last_together_at:
+          type: string
+          format: date-time
+          description: 最後に同じグループにいたとみなす日時
+          example: "2026-03-05T10:00:00Z"
 
     ThemeMode:
       type: string


### PR DESCRIPTION
## 概要

同じグループになったことがあるユーザー一覧を取得する API  
`GET /api/v1/me/shared_group_users` を実装しました。

ログインユーザーと同じグループに所属したことがあるユーザーを  
`last_together_at` の降順で取得します。

---

## 変更内容

### API
- `GET /api/v1/me/shared_group_users` を追加
- 自分自身は結果に含めない

### 実装
- `SharedGroupUsersController#index` を追加
- `Me::SharedGroupUsersQuery` を追加

### テスト
- request spec 追加
- query spec 追加

### OpenAPI
- `/api/v1/me/shared_group_users` を追加
- `SharedGroupUsersResponse` schema を追加

---

## レスポンス例

```json
{
  "shared_group_users": [
    {
      "user_id": "usr_xxx",
      "last_together_at": "2026-03-05T10:00:00Z"
    }
  ]
}
```

## 確認項目

- [x] 同じグループに所属したユーザーが取得できる
- [x] 自分自身は含まれない
- [x] last_together_at の降順で返却される
- [x] request spec / query spec が green
- [x] OpenAPI と実装が一致している

