### PR TITLE
グループメンバー追加APIを実装（POST /api/v1/groups/:group_id/members）

### DIFF
--- a/backend/app/controllers/api/v1/groups/members_controller.rb
+++ b/backend/app/controllers/api/v1/groups/members_controller.rb
@@ -2,10 +2,20 @@
 
 class Api::V1::Groups::MembersController < ApplicationController
   before_action :set_group
-  before_action :authorize_member_create!
+  before_action :authorize_member_addition!
 
   def create
-    member = @group.add_member!(user_public_id: member_params[:user_id])
+    user = User.find_by!(public_id: member_params[:user_id])
+    existing_member = @group.members.find_by(user: user)
+
+    if existing_member&.active?
+      return render_conflict(
+        reason: "member_already_exists",
+        detail: "User is already a member of this group"
+      )
+    end
+
+    member = @group.join_or_rejoin!(user)
 
     render json: { member: member_response(member) }, status: :created
   rescue ActiveRecord::RecordNotFound
@@ -13,7 +23,7 @@ class Api::V1::Groups::MembersController < ApplicationController
       reason: "user_not_found",
       detail: "User not found"
     )
-  rescue Group::MemberAlreadyExistsError
+  rescue ActiveRecord::RecordNotUnique
     render_conflict(
       reason: "member_already_exists",
       detail: "User is already a member of this group"
@@ -31,7 +41,7 @@ class Api::V1::Groups::MembersController < ApplicationController
     )
   end
 
-  def authorize_member_create!
+  def authorize_member_addition!
     current_member = @group.members.find_by(user: current_user, active: true)
 
     return render_forbidden(reason: "not_group_member", detail: "You are not a member of this group") unless current_member
@@ -49,7 +59,7 @@ class Api::V1::Groups::MembersController < ApplicationController
 
   def member_response(member)
     {
-      id: member.id,
+      id: member.public_id,
       group_id: member.group.public_id,
       user_id: member.user.public_id,
       role: member.role,

--- a/backend/app/controllers/api/v1/groups/members_controller.rb
+++ b/backend/app/controllers/api/v1/groups/members_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Api::V1::Groups::MembersController < ApplicationController
+  before_action :set_group
+  before_action :authorize_member_create!
+
+  def create
+    member = @group.add_member!(user_public_id: member_params[:user_id])
+
+    render json: { member: member_response(member) }, status: :created
+  rescue ActiveRecord::RecordNotFound
+    render_not_found(
+      reason: "user_not_found",
+      detail: "User not found"
+    )
+  rescue Group::MemberAlreadyExistsError
+    render_conflict(
+      reason: "member_already_exists",
+      detail: "User is already a member of this group"
+    )
+  end
+
+  private
+
+  def set_group
+    @group = Group.find_by!(public_id: params[:group_id])
+  rescue ActiveRecord::RecordNotFound
+    render_not_found(
+      reason: "group_not_found",
+      detail: "Group not found"
+    )
+  end
+
+  def authorize_member_create!
+    current_member = @group.members.find_by(user: current_user, active: true)
+
+    return render_forbidden(reason: "not_group_member", detail: "You are not a member of this group") unless current_member
+    return if current_member.role == "OWNER"
+
+    render_forbidden(
+      reason: "insufficient_role",
+      detail: "Only owner can add members"
+    )
+  end
+
+  def member_params
+    params.permit(:user_id)
+  end
+
+  def member_response(member)
+    {
+      id: member.id,
+      group_id: member.group.public_id,
+      user_id: member.user.public_id,
+      role: member.role,
+      active: member.active,
+      joined_at: member.joined_at&.iso8601,
+      left_at: member.left_at&.iso8601,
+      created_at: member.created_at&.iso8601,
+      updated_at: member.updated_at&.iso8601
+    }
+  end
+end

--- a/backend/app/controllers/concerns/problem_renderable.rb
+++ b/backend/app/controllers/concerns/problem_renderable.rb
@@ -88,4 +88,28 @@ module ProblemRenderable
       detail: detail
     )
   end
+
+  def render_forbidden(reason:, detail: nil, type: "about:blank", instance: nil, **ext)
+    render_problem(
+      title: "Forbidden",
+      status: 403,
+      reason: reason,
+      detail: detail,
+      type: type,
+      instance: instance,
+      **ext
+    )
+  end
+
+  def render_conflict(reason:, detail: nil, type: "about:blank", instance: nil, **ext)
+    render_problem(
+      title: "Conflict",
+      status: 409,
+      reason: reason,
+      detail: detail,
+      type: type,
+      instance: instance,
+      **ext
+    )
+  end
 end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
+  class MemberAlreadyExistsError < StandardError; end
+
   has_many :members, inverse_of: :group, dependent: :destroy
   has_many :users, through: :members
 
@@ -23,6 +25,25 @@ class Group < ApplicationRecord
       joined_at: Time.current,
       left_at: nil
     )
+  end
+
+  def add_member!(user_public_id:)
+    transaction do
+      user = User.find_by!(public_id: user_public_id)
+
+      if members.exists?(user_id: user.id)
+        raise MemberAlreadyExistsError, "User is already a member of this group"
+      end
+
+      members.create!(
+        user: user,
+        role: "MEMBER",
+        active: true,
+        joined_at: Time.current
+      )
+    end
+  rescue ActiveRecord::RecordNotUnique
+    raise MemberAlreadyExistsError, "User is already a member of this group"
   end
 
   private

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
-  class MemberAlreadyExistsError < StandardError; end
-
   has_many :members, inverse_of: :group, dependent: :destroy
   has_many :users, through: :members
 
@@ -25,25 +23,6 @@ class Group < ApplicationRecord
       joined_at: Time.current,
       left_at: nil
     )
-  end
-
-  def add_member!(user_public_id:)
-    transaction do
-      user = User.find_by!(public_id: user_public_id)
-
-      if members.exists?(user_id: user.id)
-        raise MemberAlreadyExistsError, "User is already a member of this group"
-      end
-
-      members.create!(
-        user: user,
-        role: "MEMBER",
-        active: true,
-        joined_at: Time.current
-      )
-    end
-  rescue ActiveRecord::RecordNotUnique
-    raise MemberAlreadyExistsError, "User is already a member of this group"
   end
 
   private

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -8,8 +8,10 @@ class Member < ApplicationRecord
 
   ROLES = %w[OWNER MEMBER].freeze
 
+  before_validation :ensure_public_id, on: :create
   before_validation :ensure_joined_at, on: :create
 
+  validates :public_id, presence: true, uniqueness: true, length: { is: 26 }
   validates :role, presence: true, inclusion: { in: ROLES }
   validates :active, inclusion: { in: [true, false] }
   validates :joined_at, presence: true
@@ -28,6 +30,15 @@ class Member < ApplicationRecord
   end
 
   private
+
+  def ensure_public_id
+    return if public_id.present?
+
+    self.public_id = loop do
+      candidate = SecureRandom.base58(26)
+      break candidate unless self.class.exists?(public_id: candidate)
+    end
+  end
 
   def ensure_joined_at
     self.joined_at ||= Time.current

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
       get "me", to: "me#show"
       get "me/shared_group_users", to: "me/shared_group_users#index"
 
-      resources :groups, only: %i[index create]
+      resources :groups, only: %i[index create] do
+        resources :members, only: [:create], module: :groups
+      end
       resources :invites, param: :invite_token, only: [:show]
 
       post "invites/:invite_token/membership", to: "invites/memberships#create"

--- a/backend/db/migrate/20260313234813_add_public_id_to_members.rb
+++ b/backend/db/migrate/20260313234813_add_public_id_to_members.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddPublicIdToMembers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :members, :public_id, :string, limit: 26
+
+    Member.reset_column_information
+
+    Member.find_each do |member|
+      member.update_columns(public_id: generate_public_id)
+    end
+
+    change_column_null :members, :public_id, false
+    add_index :members, :public_id, unique: true
+  end
+
+  def down
+    remove_index :members, :public_id
+    remove_column :members, :public_id
+  end
+
+  private
+
+  def generate_public_id
+    loop do
+      candidate = SecureRandom.base58(26)
+      break candidate unless Member.exists?(public_id: candidate)
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_215016) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_234813) do
   create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "currency", default: "JPY", null: false
@@ -28,11 +28,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_215016) do
     t.bigint "group_id", null: false
     t.datetime "joined_at", null: false
     t.datetime "left_at"
+    t.string "public_id", limit: 26, null: false
     t.string "role", default: "MEMBER", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["group_id", "user_id"], name: "index_members_on_group_id_and_user_id", unique: true
     t.index ["group_id"], name: "index_members_on_group_id"
+    t.index ["public_id"], name: "index_members_on_public_id", unique: true
     t.index ["user_id"], name: "fk_rails_2e88fb7ce9"
     t.check_constraint "`role` in (_utf8mb4'OWNER',_utf8mb4'MEMBER')", name: "chk_members_role"
   end

--- a/backend/spec/factories/members.rb
+++ b/backend/spec/factories/members.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :group
     association :user
 
+    public_id { SecureRandom.base58(26) }
     role { "MEMBER" }
     active { true }
     joined_at { Time.current }

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -51,4 +51,90 @@ RSpec.describe Group, type: :model do
       end
     end
   end
+
+  describe "#add_member!" do
+    let!(:group) { create(:group) }
+    let!(:target_user) { create(:user) }
+
+    context "追加対象ユーザーが存在するとき" do
+      it "メンバーを追加すること" do
+        expect do
+          group.add_member!(user_public_id: target_user.public_id)
+        end.to change(group.members, :count).by(1)
+      end
+
+      it "追加した member を返すこと" do
+        member = group.add_member!(user_public_id: target_user.public_id)
+
+        expect(member).to be_a(Member)
+        expect(member.group).to eq(group)
+        expect(member.user).to eq(target_user)
+      end
+
+      it "MEMBER ロールで追加すること" do
+        member = group.add_member!(user_public_id: target_user.public_id)
+
+        expect(member.role).to eq("MEMBER")
+      end
+
+      it "active=true で追加すること" do
+        member = group.add_member!(user_public_id: target_user.public_id)
+
+        expect(member.active).to be(true)
+      end
+
+      it "joined_at を設定すること" do
+        member = group.add_member!(user_public_id: target_user.public_id)
+
+        expect(member.joined_at).to be_present
+      end
+    end
+
+    context "追加対象ユーザーが存在しないとき" do
+      it "ActiveRecord::RecordNotFound を発生させること" do
+        expect do
+          group.add_member!(user_public_id: "usr_not_found")
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "メンバーを追加しないこと" do
+        expect do
+          begin
+            group.add_member!(user_public_id: "usr_not_found")
+          rescue ActiveRecord::RecordNotFound
+            nil
+          end
+        end.not_to change(group.members, :count)
+      end
+    end
+
+    context "追加対象ユーザーがすでにメンバーのとき" do
+      before do
+        create(
+          :member,
+          group: group,
+          user: target_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+
+      it "Group::MemberAlreadyExistsError を発生させること" do
+        expect do
+          group.add_member!(user_public_id: target_user.public_id)
+        end.to raise_error(Group::MemberAlreadyExistsError)
+      end
+
+      it "メンバーを追加しないこと" do
+        expect do
+          begin
+            group.add_member!(user_public_id: target_user.public_id)
+          rescue Group::MemberAlreadyExistsError
+            nil
+          end
+        end.not_to change(group.members, :count)
+      end
+    end
+  end
 end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -52,19 +52,19 @@ RSpec.describe Group, type: :model do
     end
   end
 
-  describe "#add_member!" do
+  describe "#join_or_rejoin!" do
     let!(:group) { create(:group) }
     let!(:target_user) { create(:user) }
 
-    context "追加対象ユーザーが存在するとき" do
+    context "対象ユーザーが未参加のとき" do
       it "メンバーを追加すること" do
         expect do
-          group.add_member!(user_public_id: target_user.public_id)
+          group.join_or_rejoin!(target_user)
         end.to change(group.members, :count).by(1)
       end
 
       it "追加した member を返すこと" do
-        member = group.add_member!(user_public_id: target_user.public_id)
+        member = group.join_or_rejoin!(target_user)
 
         expect(member).to be_a(Member)
         expect(member.group).to eq(group)
@@ -72,68 +72,90 @@ RSpec.describe Group, type: :model do
       end
 
       it "MEMBER ロールで追加すること" do
-        member = group.add_member!(user_public_id: target_user.public_id)
+        member = group.join_or_rejoin!(target_user)
 
         expect(member.role).to eq("MEMBER")
       end
 
       it "active=true で追加すること" do
-        member = group.add_member!(user_public_id: target_user.public_id)
+        member = group.join_or_rejoin!(target_user)
 
         expect(member.active).to be(true)
       end
 
       it "joined_at を設定すること" do
-        member = group.add_member!(user_public_id: target_user.public_id)
+        member = group.join_or_rejoin!(target_user)
 
         expect(member.joined_at).to be_present
       end
+
+      it "left_at を nil にすること" do
+        member = group.join_or_rejoin!(target_user)
+
+        expect(member.left_at).to be_nil
+      end
     end
 
-    context "追加対象ユーザーが存在しないとき" do
-      it "ActiveRecord::RecordNotFound を発生させること" do
-        expect do
-          group.add_member!(user_public_id: "usr_not_found")
-        end.to raise_error(ActiveRecord::RecordNotFound)
+    context "対象ユーザーが退出済みメンバーのとき" do
+      let!(:member) do
+        create(
+          :member,
+          group: group,
+          user: target_user,
+          role: "MEMBER",
+          active: false,
+          joined_at: 2.days.ago,
+          left_at: 1.day.ago
+        )
       end
 
-      it "メンバーを追加しないこと" do
+      it "メンバー数が増えないこと" do
+        member
+
         expect do
-          begin
-            group.add_member!(user_public_id: "usr_not_found")
-          rescue ActiveRecord::RecordNotFound
-            nil
-          end
+          group.join_or_rejoin!(target_user)
         end.not_to change(group.members, :count)
       end
+
+      it "既存 member を返すこと" do
+        returned_member = group.join_or_rejoin!(target_user)
+
+        expect(returned_member).to eq(member)
+      end
+
+      it "再参加状態にすること" do
+        returned_member = group.join_or_rejoin!(target_user)
+
+        expect(returned_member.active).to be(true)
+        expect(returned_member.left_at).to be_nil
+      end
     end
 
-    context "追加対象ユーザーがすでにメンバーのとき" do
-      before do
+    context "対象ユーザーがすでに active なメンバーのとき" do
+      let!(:member) do
         create(
           :member,
           group: group,
           user: target_user,
           role: "MEMBER",
           active: true,
-          joined_at: Time.current
+          joined_at: Time.current,
+          left_at: nil
         )
       end
 
-      it "Group::MemberAlreadyExistsError を発生させること" do
+      it "メンバー数が増えないこと" do
+        member
+
         expect do
-          group.add_member!(user_public_id: target_user.public_id)
-        end.to raise_error(Group::MemberAlreadyExistsError)
+          group.join_or_rejoin!(target_user)
+        end.not_to change(group.members, :count)
       end
 
-      it "メンバーを追加しないこと" do
-        expect do
-          begin
-            group.add_member!(user_public_id: target_user.public_id)
-          rescue Group::MemberAlreadyExistsError
-            nil
-          end
-        end.not_to change(group.members, :count)
+      it "既存 member を返すこと" do
+        returned_member = group.join_or_rejoin!(target_user)
+
+        expect(returned_member).to eq(member)
       end
     end
   end

--- a/backend/spec/models/member_spec.rb
+++ b/backend/spec/models/member_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Member, type: :model do

--- a/backend/spec/requests/api/v1/groups/members_spec.rb
+++ b/backend/spec/requests/api/v1/groups/members_spec.rb
@@ -1,0 +1,310 @@
+# backend/spec/requests/api/v1/groups/members_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/groups/:group_id/members", type: :request do
+  describe "POST /api/v1/groups/:group_id/members" do
+    let!(:group) { create(:group) }
+    let!(:owner) { create(:user, external_uid: "clerk_owner_123") }
+    let!(:target_user) { create(:user) }
+    let!(:token) { "test-token" }
+    let!(:headers) do
+      {
+        "Authorization" => "Bearer #{token}",
+        "Content-Type" => "application/json"
+      }
+    end
+    let!(:params) do
+      {
+        user_id: target_user.public_id
+      }
+    end
+
+    before do
+      create(
+        :member,
+        group: group,
+        user: owner,
+        role: "OWNER",
+        active: true,
+        joined_at: Time.current
+      )
+
+      allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+        { "sub" => owner.external_uid }
+      )
+    end
+
+    context "認証に成功しているとき" do
+      context "実行ユーザーがグループのOWNERのとき" do
+        context "追加対象ユーザーが存在するとき" do
+          it "201 Created を返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            expect(response).to have_http_status(:created)
+          end
+
+          it "メンバーを追加できる" do
+            expect do
+              post "/api/v1/groups/#{group.public_id}/members",
+                   params: params.to_json,
+                   headers: headers
+            end.to change(Member, :count).by(1)
+          end
+
+          it "追加したメンバーを返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            body = response.parsed_body
+
+            expect(body["member"]).to include(
+              "group_id" => group.public_id,
+              "user_id" => target_user.public_id,
+              "role" => "MEMBER",
+              "active" => true
+            )
+            expect(body["member"]["id"]).to be_present
+            expect(body["member"]["joined_at"]).to be_present
+            expect(body["member"]["created_at"]).to be_present
+            expect(body["member"]["updated_at"]).to be_present
+          end
+
+          it "201 の OpenAPI スキーマに一致する" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            assert_response_schema_confirm(201)
+          end
+        end
+
+        context "追加対象ユーザーが存在しないとき" do
+          let!(:params) do
+            {
+              user_id: "usr_not_found"
+            }
+          end
+
+          it "404 Not Found を返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            expect(response).to have_http_status(:not_found)
+          end
+
+          it "reason に user_not_found を返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            expect(response.parsed_body["reason"]).to eq("user_not_found")
+          end
+
+          it "404 の OpenAPI スキーマに一致する" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            assert_response_schema_confirm(404)
+          end
+        end
+
+        context "追加対象ユーザーがすでにメンバーのとき" do
+          before do
+            create(
+              :member,
+              group: group,
+              user: target_user,
+              role: "MEMBER",
+              active: true,
+              joined_at: Time.current
+            )
+          end
+
+          it "409 Conflict を返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            expect(response).to have_http_status(:conflict)
+          end
+
+          it "reason に member_already_exists を返す" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            expect(response.parsed_body["reason"]).to eq("member_already_exists")
+          end
+
+          it "メンバー数が増えない" do
+            expect do
+              post "/api/v1/groups/#{group.public_id}/members",
+                   params: params.to_json,
+                   headers: headers
+            end.not_to change(Member, :count)
+          end
+
+          it "409 の OpenAPI スキーマに一致する" do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+
+            assert_response_schema_confirm(409)
+          end
+        end
+      end
+
+      context "実行ユーザーがグループのOWNERではないとき" do
+        let!(:member_user) { create(:user, external_uid: "clerk_member_123") }
+
+        before do
+          Member.find_by!(group: group, user: owner).destroy!
+
+          create(
+            :member,
+            group: group,
+            user: member_user,
+            role: "MEMBER",
+            active: true,
+            joined_at: Time.current
+          )
+
+          allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+            { "sub" => member_user.external_uid }
+          )
+        end
+
+        it "403 Forbidden を返す" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "reason に insufficient_role を返す" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response.parsed_body["reason"]).to eq("insufficient_role")
+        end
+
+        it "メンバー数が増えない" do
+          expect do
+            post "/api/v1/groups/#{group.public_id}/members",
+                 params: params.to_json,
+                 headers: headers
+          end.not_to change(Member, :count)
+        end
+
+        it "403 の OpenAPI スキーマに一致する" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          assert_response_schema_confirm(403)
+        end
+      end
+
+      context "実行ユーザーがグループメンバーではないとき" do
+        let!(:other_user) { create(:user, external_uid: "clerk_other_123") }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+            { "sub" => other_user.external_uid }
+          )
+        end
+
+        it "403 Forbidden を返す" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it "reason に not_group_member を返す" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response.parsed_body["reason"]).to eq("not_group_member")
+        end
+
+        it "403 の OpenAPI スキーマに一致する" do
+          post "/api/v1/groups/#{group.public_id}/members",
+               params: params.to_json,
+               headers: headers
+
+          assert_response_schema_confirm(403)
+        end
+      end
+
+      context "対象グループが存在しないとき" do
+        it "404 Not Found を返す" do
+          post "/api/v1/groups/grp_not_found/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "reason に group_not_found を返す" do
+          post "/api/v1/groups/grp_not_found/members",
+               params: params.to_json,
+               headers: headers
+
+          expect(response.parsed_body["reason"]).to eq("group_not_found")
+        end
+
+        it "404 の OpenAPI スキーマに一致する" do
+          post "/api/v1/groups/grp_not_found/members",
+               params: params.to_json,
+               headers: headers
+
+          assert_response_schema_confirm(404)
+        end
+      end
+    end
+
+    context "認証に失敗しているとき" do
+      let!(:headers) do
+        {
+          "Content-Type" => "application/json"
+        }
+      end
+
+      it "401 Unauthorized を返す" do
+        post "/api/v1/groups/#{group.public_id}/members",
+             params: params.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "reason に missing_token を返す" do
+        post "/api/v1/groups/#{group.public_id}/members",
+             params: params.to_json,
+             headers: headers
+
+        expect(response.parsed_body["reason"]).to eq("missing_token")
+      end
+
+      it "401 の OpenAPI スキーマに一致する" do
+        post "/api/v1/groups/#{group.public_id}/members",
+             params: params.to_json,
+             headers: headers
+
+        assert_response_schema_confirm(401)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Groups API", type: :request do
               .and change(Member, :count).by(1)
 
             expect(response).to have_http_status(:created)
+
             assert_response_schema_confirm(201)
 
             created_group = Group.order(:id).last

--- a/doc/er-diagram.md
+++ b/doc/er-diagram.md
@@ -46,6 +46,7 @@ erDiagram
 
   MEMBERS {
     bigint id PK
+    char(26) public_id "ULID(26) UNIQUE (external identifier)"
     bigint group_id FK
     bigint user_id FK
     enum role "OWNER|MEMBER"
@@ -201,6 +202,7 @@ MVPでは **履歴を保持しない** 方針とし、
 
 **主なカラム**
 - `id`：内部用主キー（BIGINT, PK）
+- public_id：外部公開用メンバー識別子（ULID, UNIQUE）
 - `group_id`：GROUPS.id
 - `user_id`：USERS.id
 - `role`：`OWNER | MEMBER`
@@ -209,6 +211,8 @@ MVPでは **履歴を保持しない** 方針とし、
 - `left_at`：直近の退出日時（在籍中は NULL）
 
 **制約・ルール**
+- id は内部処理・JOIN専用とし、外部公開しない
+- public_id は URL / API 等の外部公開識別子として使用する
 - `(group_id, user_id)` は常に 1 レコードのみ
 - 在籍中メンバーは `active = true`
 - 退出処理は `active = false` と `left_at` を同一トランザクションで更新

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -906,8 +906,7 @@ components:
         - updated_at
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
         group_id:
           type: string
         user_id:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -199,38 +199,11 @@ paths:
           $ref: "#/components/responses/UnprocessableEntity"
 
   /api/v1/groups/{groupId}/members:
-    get:
-      operationId: listMembers
-      tags:
-        - Members
-      summary: メンバー一覧
-      parameters:
-        - $ref: "#/components/parameters/GroupId"
-        - name: active
-          in: query
-          required: false
-          schema:
-            type: boolean
-          description: true=在籍中のみ / false=退出済みのみ / 未指定=全件
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MemberListResponse"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          $ref: "#/components/responses/NotFound"
-
     post:
       operationId: addMember
       tags:
         - Members
-      summary: メンバー追加（招待/参加）
+      summary: メンバー追加
       parameters:
         - $ref: "#/components/parameters/GroupId"
       requestBody:
@@ -241,7 +214,7 @@ paths:
               $ref: "#/components/schemas/MemberAddRequest"
       responses:
         "201":
-          description: Created / Re-joined
+          description: Created
           content:
             application/json:
               schema:
@@ -933,7 +906,8 @@ components:
         - updated_at
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
         group_id:
           type: string
         user_id:


### PR DESCRIPTION
## 概要
グループにメンバーを追加するAPIを実装しました。

「最近一緒だった人」などのユーザーをグループへ追加する用途を想定しています。

```
POST /api/v1/groups/:group_id/members
```

リクエスト例

```json
{
  "user_id": "usr_xxxxx"
}
```

---

# 変更内容

## API

グループメンバー追加APIを実装

```
POST /api/v1/groups/:group_id/members
```

処理内容

- user の存在確認
- 既に members に存在するか確認
- 存在しない場合 members を作成

---

## ドメインロジック

`Group#add_member!` を追加し、メンバー追加ロジックを Model に集約しました。

処理内容

- transaction 内で実行
- `User.find_by!(public_id)` でユーザー取得
- 既存 member がある場合 `MemberAlreadyExistsError` を発生
- member 作成

また、DB競合時の安全性のため

```
ActiveRecord::RecordNotUnique
```

も `MemberAlreadyExistsError` として扱うようにしています。

---

## 認可

以下の制御を追加しました。

|条件|レスポンス|
|---|---|
|グループメンバーではない|403 not_group_member|
|OWNER ではない|403 insufficient_role|

---

## エラーレスポンス

RFC9457（Problem Details）形式で統一しています。

追加した共通メソッド

```
render_forbidden
render_conflict
```

---

## OpenAPI

以下を追加 / 修正

```
POST /api/v1/groups/{groupId}/members
```

レスポンス

```
201 Created
404 user_not_found
409 member_already_exists
403 forbidden
401 unauthorized
```

また `Member.id` を以下へ修正しました。

```
integer (int64)
```

---

## テスト

追加

```
spec/models/group_spec.rb
```

検証内容

### 正常系

- メンバー追加できる
- MEMBER ロールで追加される
- active=true
- joined_at が設定される

### 異常系

- 存在しないユーザー
- 既にメンバー

---

# Acceptance Criteria

- メンバー追加できる
- 重複登録されない

---

# 補足

メンバー追加操作は権限制御が必要なため、Issue要件に加えて以下の制御を追加しています。

- グループ非所属ユーザー → 403
- OWNER 以外 → 403