### PR TITLE
feat: 招待トークン再生成APIを追加する

### DIFF
--- a/backend/app/controllers/api/v1/groups/invite_tokens_controller.rb
+++ b/backend/app/controllers/api/v1/groups/invite_tokens_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Groups
+      class InviteTokensController < ApplicationController
+        before_action :set_group
+        before_action :authorize_owner!
+
+        def update
+          @group.regenerate_invite_token!
+
+          render json: {
+            invite_token: @group.invite_token,
+            invite_token_expires_at: @group.invite_token_expires_at.iso8601
+          }, status: :ok
+        rescue ActiveRecord::RecordInvalid => e
+          render_validation_error(e.record)
+        end
+
+        private
+
+        def set_group
+          return if performed?
+
+          @group = Group.find_by(public_id: params[:group_id])
+          return if @group.present?
+
+          render_not_found(
+            reason: "group_not_found",
+            detail: "Group not found"
+          )
+        end
+
+        def authorize_owner!
+          return if performed?
+          return if @group.members.exists?(user: current_user, role: "OWNER", active: true)
+
+          render_forbidden(
+            reason: "forbidden",
+            detail: "You are not allowed to regenerate invite token for this group"
+          )
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/groups/invite_tokens_controller.rb
+++ b/backend/app/controllers/api/v1/groups/invite_tokens_controller.rb
@@ -34,8 +34,7 @@ module Api
 
         def authorize_owner!
           return if performed?
-          return if @group.members.exists?(user: current_user, role: "OWNER", active: true)
-
+          return if @group.members.exists?(user: current_user, role: Member::ROLE_OWNER, active: true)
           render_forbidden(
             reason: "forbidden",
             detail: "You are not allowed to regenerate invite token for this group"

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -30,6 +30,13 @@ class Group < ApplicationRecord
     end
   end
 
+  def regenerate_invite_token!
+    update!(
+      invite_token: generate_unique_invite_token,
+      invite_token_expires_at: Time.current + INVITE_TOKEN_EXPIRES_IN
+    )
+  end
+
   def invite_token_active?
     invite_token_expires_at.present? && invite_token_expires_at > Time.current
   end
@@ -48,15 +55,19 @@ class Group < ApplicationRecord
   def ensure_invite_token
     return if invite_token.present?
 
-    self.invite_token = loop do
-      candidate = SecureRandom.base58(32)
-      break candidate unless self.class.exists?(invite_token: candidate)
-    end
+    self.invite_token = generate_unique_invite_token
   end
 
   def ensure_invite_token_expires_at
     return if invite_token_expires_at.present?
 
     self.invite_token_expires_at = Time.current + INVITE_TOKEN_EXPIRES_IN
+  end
+
+  def generate_unique_invite_token
+    loop do
+      candidate = SecureRandom.base58(32)
+      break candidate unless self.class.exists?(invite_token: candidate)
+    end
   end
 end

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -7,6 +7,8 @@ class Member < ApplicationRecord
   belongs_to :user, inverse_of: :members
 
   ROLES = %w[OWNER MEMBER].freeze
+  ROLE_OWNER = "OWNER"
+  ROLE_MEMBER = "MEMBER"
 
   before_validation :ensure_public_id, on: :create
   before_validation :ensure_joined_at, on: :create

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
 
       resources :groups, only: %i[index create] do
         resources :members, only: [:create], module: :groups
+        resource :invite_token, only: [:update], module: :groups
       end
+
       resources :invites, param: :invite_token, only: [:show]
 
       post "invites/:invite_token/membership", to: "invites/memberships#create"

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -243,4 +243,42 @@ RSpec.describe Group, type: :model do
       end
     end
   end
+
+  describe "#regenerate_invite_token!" do
+    around do |example|
+      freeze_time { example.run }
+    end
+
+    let!(:group) do
+      create(
+        :group,
+        invite_token: "old_invite_token",
+        invite_token_expires_at: 12.hours.from_now
+      )
+    end
+
+    context "招待トークンを再生成するとき" do
+      it "invite_token が更新されること" do
+        old_token = group.invite_token
+
+        group.regenerate_invite_token!
+
+        expect(group.reload.invite_token).not_to eq(old_token)
+      end
+
+      it "invite_token_expires_at が更新されること" do
+        group.regenerate_invite_token!
+
+        expect(group.reload.invite_token_expires_at).to eq(24.hours.from_now)
+      end
+
+      it "旧トークンと異なる値になること" do
+        old_token = group.invite_token
+
+        group.regenerate_invite_token!
+
+        expect(group.reload.invite_token).not_to eq(old_token)
+      end
+    end
+  end
 end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -271,14 +271,6 @@ RSpec.describe Group, type: :model do
 
         expect(group.reload.invite_token_expires_at).to eq(24.hours.from_now)
       end
-
-      it "旧トークンと異なる値になること" do
-        old_token = group.invite_token
-
-        group.regenerate_invite_token!
-
-        expect(group.reload.invite_token).not_to eq(old_token)
-      end
     end
   end
 end

--- a/backend/spec/requests/api/v1/groups/invite_tokens_spec.rb
+++ b/backend/spec/requests/api/v1/groups/invite_tokens_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "PATCH /api/v1/groups/:group_id/invite_token", type: :request do
       :member,
       group: group,
       user: owner,
-      role: "OWNER",
+      role: Member::ROLE_OWNER,
       active: true,
       joined_at: Time.current
     )
@@ -96,17 +96,74 @@ RSpec.describe "PATCH /api/v1/groups/:group_id/invite_token", type: :request do
           :member,
           group: group,
           user: member_user,
-          role: "MEMBER",
+          role: Member::ROLE_MEMBER,
           active: true,
           joined_at: Time.current
         )
       end
 
       before do
-        member_record
-
         allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
           { "sub" => member_user.external_uid }
+        )
+      end
+
+      it "403を返すこと" do
+        do_request
+
+        expect(response).to have_http_status(:forbidden), response.body
+        assert_response_schema_confirm(403)
+
+        body = JSON.parse(response.body)
+        expect(response.content_type).to include("application/problem+json")
+        expect(body["title"]).to eq("Forbidden")
+        expect(body["status"]).to eq(403)
+        expect(body["reason"]).to eq("forbidden")
+        expect(body["detail"]).to be_present
+      end
+    end
+
+    context "実行ユーザーが active: false の元オーナーのとき" do
+      let!(:inactive_owner_user) { create(:user) }
+      let!(:inactive_owner_member) do
+        create(
+          :member,
+          group: group,
+          user: inactive_owner_user,
+          role: Member::ROLE_OWNER,
+          active: false,
+          joined_at: 2.days.ago,
+          left_at: 1.day.ago
+        )
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => inactive_owner_user.external_uid }
+        )
+      end
+
+      it "403を返すこと" do
+        do_request
+
+        expect(response).to have_http_status(:forbidden), response.body
+        assert_response_schema_confirm(403)
+
+        body = JSON.parse(response.body)
+        expect(response.content_type).to include("application/problem+json")
+        expect(body["title"]).to eq("Forbidden")
+        expect(body["status"]).to eq(403)
+        expect(body["reason"]).to eq("forbidden")
+        expect(body["detail"]).to be_present
+      end
+    end
+
+    context "実行ユーザーがグループの非メンバーユーザーのとき" do
+      let!(:non_member_user) { create(:user) }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => non_member_user.external_uid }
         )
       end
 

--- a/backend/spec/requests/api/v1/groups/invite_tokens_spec.rb
+++ b/backend/spec/requests/api/v1/groups/invite_tokens_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PATCH /api/v1/groups/:group_id/invite_token", type: :request do
+  let!(:token) { "test-token" }
+  let!(:headers) { { "Authorization" => "Bearer #{token}" } }
+
+  let!(:owner) { create(:user) }
+  let!(:member_user) { create(:user) }
+  let!(:group) do
+    create(
+      :group,
+      public_id: "12345678901234567890123456",
+      invite_token: "old_invite_token",
+      invite_token_expires_at: 12.hours.from_now
+    )
+  end
+  let!(:owner_member) do
+    create(
+      :member,
+      group: group,
+      user: owner,
+      role: "OWNER",
+      active: true,
+      joined_at: Time.current
+    )
+  end
+
+  subject(:do_request) do
+    patch "/api/v1/groups/#{target_group_id}/invite_token", headers: request_headers
+  end
+
+  let!(:target_group_id) { group.public_id }
+  let!(:request_headers) { headers }
+
+  context "認証成功時" do
+    context "実行ユーザーがオーナーのとき" do
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner.external_uid }
+        )
+      end
+
+      it "招待トークンを再生成できること" do
+        old_token = group.invite_token
+        old_expires_at = group.invite_token_expires_at
+
+        do_request
+
+        expect(response).to have_http_status(:ok), response.body
+        assert_response_schema_confirm(200)
+
+        body = JSON.parse(response.body)
+        group.reload
+
+        expect(response.content_type).to include("application/json")
+        expect(body["invite_token"]).to eq(group.invite_token)
+        expect(body["invite_token_expires_at"]).to eq(group.invite_token_expires_at.iso8601)
+        expect(body["invite_token"]).to be_present
+        expect(body["invite_token_expires_at"]).to be_present
+        expect(group.invite_token).not_to eq(old_token)
+        expect(group.invite_token_expires_at).to be > old_expires_at
+      end
+
+      it "再生成後は旧トークンで招待確認APIにアクセスできないこと" do
+        old_token = group.invite_token
+
+        do_request
+
+        expect(response).to have_http_status(:ok), response.body
+        assert_response_schema_confirm(200)
+
+        get "/api/v1/invites/#{old_token}"
+
+        expect(response).to have_http_status(:not_found), response.body
+      end
+
+      it "再生成後は新トークンで招待確認APIにアクセスできること" do
+        do_request
+
+        expect(response).to have_http_status(:ok), response.body
+        assert_response_schema_confirm(200)
+
+        new_token = JSON.parse(response.body)["invite_token"]
+
+        get "/api/v1/invites/#{new_token}"
+
+        expect(response).to have_http_status(:ok), response.body
+      end
+    end
+
+    context "実行ユーザーがオーナーではないとき" do
+      let!(:member_record) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+
+      before do
+        member_record
+
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => member_user.external_uid }
+        )
+      end
+
+      it "403を返すこと" do
+        do_request
+
+        expect(response).to have_http_status(:forbidden), response.body
+        assert_response_schema_confirm(403)
+
+        body = JSON.parse(response.body)
+        expect(response.content_type).to include("application/problem+json")
+        expect(body["title"]).to eq("Forbidden")
+        expect(body["status"]).to eq(403)
+        expect(body["reason"]).to eq("forbidden")
+        expect(body["detail"]).to be_present
+      end
+    end
+
+    context "グループが存在しないとき" do
+      let!(:target_group_id) { "not_found_group_id_123456" }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner.external_uid }
+        )
+      end
+
+      it "404を返すこと" do
+        do_request
+
+        expect(response).to have_http_status(:not_found), response.body
+        assert_response_schema_confirm(404)
+
+        body = JSON.parse(response.body)
+        expect(response.content_type).to include("application/problem+json")
+        expect(body["title"]).to eq("Not Found")
+        expect(body["status"]).to eq(404)
+        expect(body["reason"]).to eq("group_not_found")
+        expect(body["detail"]).to be_present
+      end
+    end
+  end
+
+  context "未認証のとき" do
+    let!(:request_headers) { {} }
+
+    it "401を返すこと" do
+      do_request
+
+      expect(response).to have_http_status(:unauthorized), response.body
+      assert_response_schema_confirm(401)
+
+      body = JSON.parse(response.body)
+      expect(response.content_type).to include("application/problem+json")
+      expect(body["title"]).to eq("Unauthorized")
+      expect(body["status"]).to eq(401)
+      expect(body["reason"]).to eq("missing_token")
+      expect(body["detail"]).to be_present
+    end
+  end
+end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -257,6 +257,39 @@ paths:
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
 
+  /api/v1/groups/{groupId}/invite_token:
+    patch:
+      operationId: regenerateGroupInviteToken
+      tags:
+        - Groups
+      summary: 招待トークン再生成
+      description: >
+        グループオーナーが招待トークンを再生成します。
+        再生成後は旧トークンが無効化され、新しいトークンのみ有効になります。
+      parameters:
+        - $ref: "#/components/parameters/GroupId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupInviteTokenResponse"
+              examples:
+                success:
+                  summary: 招待トークン再生成成功
+                  value:
+                    invite_token: "new_invite_token_xxxxx"
+                    invite_token_expires_at: "2026-03-21T10:14:20Z"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
+
   /api/v1/groups/{groupId}/expenses:
     get:
       operationId: listExpenses
@@ -899,6 +932,22 @@ components:
             $ref: "#/components/schemas/GroupListItem"
         meta:
           $ref: "#/components/schemas/PaginationMeta"
+
+    GroupInviteTokenResponse:
+      type: object
+      required:
+        - invite_token
+        - invite_token_expires_at
+      properties:
+        invite_token:
+          type: string
+          description: 再生成後の招待トークン
+          example: "new_invite_token_xxxxx"
+        invite_token_expires_at:
+          type: string
+          format: date-time
+          description: 招待トークンの有効期限
+          example: "2026-03-21T10:14:20Z"
 
     Member:
       type: object


### PR DESCRIPTION
## 概要

招待トークン再生成APIを追加しました。

- PATCH /api/v1/groups/:group_id/invite_token を実装
- グループオーナーのみ招待トークンを再生成可能
- 再生成時に invite_token_expires_at も更新
- 旧トークンは無効化され、新トークンのみ有効
- OpenAPI を更新
- model spec / request spec を追加

## 変更内容

### Model
- Group#regenerate_invite_token! を追加
- 招待トークン生成処理を generate_unique_invite_token に共通化

### API
- PATCH /api/v1/groups/:group_id/invite_token を追加
- Api::V1::Groups::InviteTokensController を追加
- オーナー判定を行い、再生成結果を返却

### OpenAPI
- 招待トークン再生成APIの path を追加
- GroupInviteTokenResponse schema を追加

### Test
- Group#regenerate_invite_token! の model spec を追加
- request spec を追加
  - オーナーは再生成できる
  - 非オーナーは 403
  - グループ不存在は 404
  - 未認証は 401
  - 旧トークンは無効化される
  - 新トークンは有効である

## 確認内容

bundle exec rspec

- 126 examples, 0 failures

## 補足

- エラーレスポンスは RFC9457（Problem Details）に統一しています
- OpenAPI レスポンス検証も追加しています