### PR TITLE
feat: グループ詳細APIを実装（GET /groups/{groupId}） (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ yarn-error.log*
 # TypeScript
 ####################################
 *.tsbuildinfo
+
+####################################
+# Articles (local drafts)
+####################################
+doc/articles/

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -68,7 +68,7 @@ class Api::V1::GroupsController < ApplicationController
 
   def show
     group = find_group_by_public_id
-    return render_group_not_found if group.nil?
+    return render_not_found(detail: "Group not found", reason: "not_found") if group.nil?
 
     return render_forbidden(detail: "forbidden", reason: "forbidden") unless active_membership?(group)
 
@@ -114,16 +114,6 @@ class Api::V1::GroupsController < ApplicationController
       created_at: group.created_at,
       updated_at: group.updated_at
     }
-  end
-
-  def render_group_not_found
-    render json: {
-      type: "about:blank",
-      title: "Not Found",
-      status: 404,
-      detail: "Group not found",
-      reason: "not_found"
-    }, status: :not_found, content_type: "application/problem+json"
   end
 
   def group_params

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -94,7 +94,7 @@ class Api::V1::GroupsController < ApplicationController
   end
 
   def active_members(group)
-    group.members.where(active: true)
+    group.members.where(active: true).includes(:user)
   end
 
   def active_members_json(group)

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -111,8 +111,8 @@ class Api::V1::GroupsController < ApplicationController
       public_id: group.public_id,
       name: group.name,
       currency: group.currency,
-      created_at: group.created_at,
-      updated_at: group.updated_at
+      created_at: group.created_at&.iso8601,
+      updated_at: group.updated_at&.iso8601
     }
   end
 

--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -4,22 +4,17 @@ class Api::V1::GroupsController < ApplicationController
   PER_PAGE = 20
 
   def index
-    page = params.fetch(:page, 1).to_i
-    page = 1 if page < 1
+    page = normalized_page
     per_page = PER_PAGE
 
-    # 「自分が active=true で所属している group」のみを母集団として確定
     member_group_ids = current_user
       .members
       .active
       .select(:group_id)
 
-    # total_count も同じ母集団（= 自分の active 所属グループ数）
     total_count = member_group_ids.distinct.count
 
-    #  一覧に出す group は「自分の active 所属」だけに限定した上で、
-    #  member_count は「その group の active members」を数える
-    base_scope = Group
+    groups = Group
       .where(id: member_group_ids)
       .joins(:members)
       .merge(Member.active)
@@ -31,14 +26,12 @@ class Api::V1::GroupsController < ApplicationController
          groups.updated_at,
          COUNT(members.id) AS member_count"
       )
-
-    groups = base_scope
       .order("groups.updated_at DESC")
       .limit(per_page)
       .offset((page - 1) * per_page)
 
     render json: {
-      groups: groups.map { |g| group_list_json(g) },
+      groups: groups.map { |group| group_list_json(group) },
       meta: {
         page: page,
         per_page: per_page,
@@ -73,7 +66,65 @@ class Api::V1::GroupsController < ApplicationController
     render_internal_server_error
   end
 
+  def show
+    group = find_group_by_public_id
+    return render_group_not_found if group.nil?
+
+    return render_forbidden(detail: "forbidden", reason: "forbidden") unless active_membership?(group)
+
+    render json: {
+      group: group_detail_json(group),
+      members: active_members_json(group)
+    }, status: :ok
+  end
+
   private
+
+  def normalized_page
+    page = params.fetch(:page, 1).to_i
+    page < 1 ? 1 : page
+  end
+
+  def find_group_by_public_id
+    Group.find_by(public_id: params[:id])
+  end
+
+  def active_membership?(group)
+    group.members.exists?(user: current_user, active: true)
+  end
+
+  def active_members(group)
+    group.members.where(active: true)
+  end
+
+  def active_members_json(group)
+    active_members(group).map do |member|
+      {
+        user_id: member.user.public_id,
+        role: member.role
+      }
+    end
+  end
+
+  def group_detail_json(group)
+    {
+      public_id: group.public_id,
+      name: group.name,
+      currency: group.currency,
+      created_at: group.created_at,
+      updated_at: group.updated_at
+    }
+  end
+
+  def render_group_not_found
+    render json: {
+      type: "about:blank",
+      title: "Not Found",
+      status: 404,
+      detail: "Group not found",
+      reason: "not_found"
+    }, status: :not_found, content_type: "application/problem+json"
+  end
 
   def group_params
     params.require(:group).permit(:name, :currency)
@@ -90,7 +141,6 @@ class Api::V1::GroupsController < ApplicationController
     }
   end
 
-  # GET /groups 用
   def group_list_json(group)
     {
       public_id: group.public_id,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       get "me", to: "me#show"
       get "me/shared_group_users", to: "me/shared_group_users#index"
 
-      resources :groups, only: %i[index create] do
+      resources :groups, only: %i[index create show] do
         resources :members, only: [:create], module: :groups
         resource :invite_token, only: [:update], module: :groups
       end

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Groups API", type: :request do
         context "name が不正なとき（空文字）" do
           let!(:params) { { group: { name: "", currency: "JPY" } } }
 
-          it "422 を返し、Group / Member を作成しない（Problem Details）" do
+          it "422 を返し、Group / Member を作成しない（）" do
             expect { do_request }
               .to change(Group, :count).by(0)
               .and change(Member, :count).by(0)
@@ -386,6 +386,179 @@ RSpec.describe "Groups API", type: :request do
       end
 
       context "認証失敗（Authorization: Bearer / verify! 失敗）" do
+        let!(:token) { "dummy" }
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
+            .and_raise(Clerk::JwtVerifier::VerificationError.new("decode failed"))
+        end
+
+        it "401 invalid_token を返す（Problem Details）" do
+          do_request
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(401)
+
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "invalid_token"
+          )
+        end
+      end
+    end
+  end
+
+  describe "GET /api/v1/groups/:group_id" do
+    subject(:do_request) { get "/api/v1/groups/#{group_id}", headers: headers }
+
+    describe "認証" do
+      context "認証成功（Authorization: Bearer / verify! 成功）" do
+        let!(:token) { "dummy" }
+        let!(:allowed_origin) { ENV.fetch("CORS_ALLOWED_ORIGIN", "http://localhost:8000") }
+        let!(:sub) { "user_abc" }
+        let!(:payload) { { "sub" => sub, "azp" => allowed_origin } }
+
+        let!(:headers) do
+          {
+            "Authorization" => "Bearer #{token}",
+            "Content-Type" => "application/json"
+          }
+        end
+
+        let!(:user) { create(:user, external_uid: sub) }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!).and_return(payload)
+        end
+
+        context "自分が active member として所属しているグループのとき" do
+          let!(:group) { create(:group, name: "大阪旅行", currency: "JPY") }
+          let!(:group_id) { group.public_id }
+
+          let!(:owner_user) { create(:user) }
+          let!(:inactive_user) { create(:user) }
+
+          before do
+            create(:member, group: group, user: user, role: "MEMBER", active: true, joined_at: Time.current)
+            create(:member, group: group, user: owner_user, role: "OWNER", active: true, joined_at: Time.current)
+            create(:member, group: group, user: inactive_user, role: "MEMBER", active: false, joined_at: Time.current, left_at: Time.current)
+          end
+
+          it "200 を返し、group基本情報と active な members のみを返す" do
+            do_request
+
+            expect(response).to have_http_status(:ok)
+            assert_response_schema_confirm(200)
+
+            body = response.parsed_body
+            expect(body).to be_a(Hash)
+            expect(body).to include("group", "members")
+
+            group_json = body.fetch("group")
+            expect(group_json).to include(
+              "public_id" => group.public_id,
+              "name" => "大阪旅行",
+              "currency" => "JPY"
+            )
+            expect(group_json["created_at"]).to be_a(String)
+            expect(group_json["updated_at"]).to be_a(String)
+
+            members = body.fetch("members")
+            expect(members).to be_an(Array)
+            expect(members.size).to eq(2)
+
+            returned_user_ids = members.map { |member| member.fetch("user_id") }
+            expect(returned_user_ids).to include(user.public_id, owner_user.public_id)
+            expect(returned_user_ids).not_to include(inactive_user.public_id)
+          end
+        end
+
+        context "存在しないグループIDのとき" do
+          let!(:group_id) { "grp_not_found" }
+
+          it "404 を返す" do
+            do_request
+
+            expect(response).to have_http_status(:not_found)
+            expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(404)
+          end
+        end
+
+        context "グループは存在するが、自分が所属していないとき" do
+          let!(:group) { create(:group, name: "大阪旅行", currency: "JPY") }
+          let!(:group_id) { group.public_id }
+          let!(:other_user) { create(:user) }
+
+          before do
+            create(:member, group: group, user: other_user, role: "OWNER", active: true, joined_at: Time.current)
+          end
+
+          it "403 を返す" do
+            do_request
+
+            expect(response).to have_http_status(:forbidden)
+            expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(403)
+          end
+        end
+
+        context "グループに inactive member としてのみ存在するとき" do
+          let!(:group) { create(:group, name: "大阪旅行", currency: "JPY") }
+          let!(:group_id) { group.public_id }
+
+          before do
+            create(:member, group: group, user: user, role: "MEMBER", active: false, joined_at: Time.current, left_at: Time.current)
+          end
+
+          it "403 を返す" do
+            do_request
+
+            expect(response).to have_http_status(:forbidden)
+            expect(response.media_type).to eq("application/problem+json")
+            assert_response_schema_confirm(403)
+          end
+        end
+      end
+
+      context "認証失敗（Authorization ヘッダーなし）" do
+        let!(:group_id) { "grp_dummy" }
+        let!(:headers) { { "Content-Type" => "application/json" } }
+
+        before do
+          allow(Clerk::JwtVerifier).to receive(:verify!)
+        end
+
+        it "401 missing_token を返す（Problem Details）" do
+          do_request
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(response.media_type).to eq("application/problem+json")
+          assert_response_schema_confirm(401)
+
+          expect(response.parsed_body).to include(
+            "title" => "Unauthorized",
+            "status" => 401,
+            "reason" => "missing_token"
+          )
+        end
+
+        it "Clerk::JwtVerifier.verify! を呼ばない" do
+          do_request
+          expect(Clerk::JwtVerifier).not_to have_received(:verify!)
+        end
+      end
+
+      context "認証失敗（Authorization: Bearer / verify! 失敗）" do
+        let!(:group_id) { "grp_dummy" }
         let!(:token) { "dummy" }
         let!(:headers) do
           {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -159,7 +159,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupResponse"
+                $ref: "#/components/schemas/GroupDetailResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -874,6 +874,50 @@ components:
         member_count:
           type: integer
           example: 2
+
+    GroupDetailResponse:
+      type: object
+      required:
+        - group
+        - members
+      properties:
+        group:
+          type: object
+          required:
+            - public_id
+            - name
+            - currency
+            - created_at
+            - updated_at
+          properties:
+            public_id:
+              type: string
+              example: MyjusiApaCFaYhQVSEAxzjs6Bw
+            name:
+              type: string
+              example: 大阪旅行
+            currency:
+              type: string
+              example: JPY
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+        members:
+          type: array
+          items:
+            type: object
+            required:
+              - user_id
+              - role
+            properties:
+              user_id:
+                type: string
+                example: 01H00000000000000000000015
+              role:
+                $ref: "#/components/schemas/MemberRole"
 
     GroupCreateRequest:
       type: object


### PR DESCRIPTION
## 📌 概要

グループ詳細 API（`GET /api/v1/groups/{groupId}`）を実装しました。

グループ詳細画面の前提となる API を提供し、
グループの基本情報およびメンバー一覧を取得できるようにしています。

---

## 🎯 目的

* グループ詳細ページの表示に必要なデータを取得可能にする
* UI実装の前提となる API を整備する
* API契約（OpenAPI）と実装を一致させる

---

## ✨ 実装内容

### 1. エンドポイント追加

* `GET /api/v1/groups/{groupId}` を追加

### 2. レスポンス仕様

以下を返却するように実装

* `group`

  * public_id
  * name
  * currency
  * created_at
  * updated_at
* `members`

  * active=true のみ
  * user_id / role

---

### 3. エラーハンドリング（RFC9457準拠）

* 存在しないグループ

  * `404 Not Found`
  * `application/problem+json`
* 未所属（または inactive のみ）

  * `403 Forbidden`
  * `application/problem+json`
* 認証失敗

  * `401 Unauthorized`

---

### 4. Request Spec

以下のケースを網羅

#### 正常系

* active member として所属している場合

  * 200 を返す
  * active member のみ返却される

#### 異常系

* 存在しない groupId → 404
* 未所属 → 403
* inactive のみ → 403

#### 認証

* Authorization ヘッダーなし → 401
* トークン検証失敗 → 401

👉 正常系 / 異常系 / 認証 を context で分離

---

### 5. OpenAPI 更新

* `GroupDetailResponse` を追加
* `/groups/{groupId}` の 200 レスポンスを定義
* ProblemDetails と整合

---

## 🧪 テスト結果

```bash
bundle exec rspec spec/requests/api/v1/groups_spec.rb
```

```
21 examples, 0 failures
```

---

## 🔧 補足

* コントローラー内のロジックを private メソッドへ分離し、可読性を改善
* `.gitignore` に `doc/articles/` を追加（ローカル記事管理用）

---

## 🚫 スコープ外

* フロントエンド実装
* メンバー追加・更新機能

---

## 📎 関連 Issue

* closes #24

---
