### PR TITLE
feature: メンバー追加UI実装（暫定：userId入力ベース） #27

### DIFF
--- a/frontend/src/app/(dashboard)/groups/[groupId]/_components/AddMemberForm.tsx
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_components/AddMemberForm.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { addMemberSchema, type AddMemberValues } from "../_schemas/addMemberSchema"
+import { useAddMemberSubmit } from "../_hooks/useAddMemberSubmit"
+
+const styles = {
+  label: "block text-sm font-semibold text-white/90",
+  input:
+    "mt-2 w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/40 outline-none transition focus:border-emerald-400/40 focus:ring-2 focus:ring-emerald-300/20",
+  error: "mt-2 text-xs text-rose-200",
+  success: "mt-2 text-xs text-emerald-300",
+  notice: "mb-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-white/80",
+  submit:
+    "inline-flex items-center justify-center rounded-full bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50",
+} as const
+
+type Props = {
+  groupId: string
+  onSuccess: () => void
+}
+
+export function AddMemberForm({ groupId, onSuccess }: Props) {
+  const [succeeded, setSucceeded] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting, isValid },
+    setError,
+  } = useForm<AddMemberValues>({
+    resolver: zodResolver(addMemberSchema),
+    mode: "onChange",
+    defaultValues: { user_id: "" },
+  })
+
+  const handleSuccess = useCallback(() => {
+    reset()
+    setSucceeded(true)
+    onSuccess()
+  }, [reset, onSuccess])
+
+  const { submit } = useAddMemberSubmit(groupId, setError, handleSuccess)
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate className="mt-4 flex flex-col gap-3">
+      {errors.root?.message && <p className={styles.notice}>{errors.root.message}</p>}
+      <div>
+        <label htmlFor="user_id" className={styles.label}>
+          ユーザーID
+        </label>
+        <input
+          id="user_id"
+          type="text"
+          placeholder="例：3yKqJ7mNpX2aRvL8tWdF4eUhC1"
+          className={styles.input}
+          {...register("user_id")}
+          aria-invalid={Boolean(errors.user_id)}
+          disabled={isSubmitting}
+        />
+        {errors.user_id?.message && <p className={styles.error}>{errors.user_id.message}</p>}
+        {succeeded && !errors.user_id && (
+          <p className={styles.success}>メンバーを追加しました。</p>
+        )}
+      </div>
+      <div>
+        <button type="submit" className={styles.submit} disabled={!isValid || isSubmitting}>
+          {isSubmitting ? "追加中..." : "メンバーを追加"}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useAddMemberSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useAddMemberSubmit.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useCallback } from "react"
+import type { UseFormSetError } from "react-hook-form"
+import { addMember } from "@/lib/api/groups"
+import type { ApiError } from "@/lib/api/problemDetailsError"
+import { useRequireAuth } from "@/hooks/useRequireAuth"
+import type { AddMemberValues } from "../_schemas/addMemberSchema"
+
+export function useAddMemberSubmit(
+  groupId: string,
+  setError: UseFormSetError<AddMemberValues>,
+  onSuccess: () => void
+) {
+  const { requireToken } = useRequireAuth()
+
+  const submit = useCallback(
+    async (values: AddMemberValues): Promise<void> => {
+      const token = await requireToken(`/groups/${groupId}`)
+      if (!token) {
+        setError("root", { type: "server", message: "ログインが必要です。" })
+        return
+      }
+
+      try {
+        await addMember(groupId, { user_id: values.user_id }, { token })
+        onSuccess()
+      } catch (e) {
+        const err = e as ApiError
+
+        if (err.code === "NOT_FOUND") {
+          setError("user_id", { type: "server", message: "ユーザーが見つかりません。" })
+          return
+        }
+        // 409 は ApiErrorCode に定義がないため status で判定
+        if (err.status === 409) {
+          setError("user_id", { type: "server", message: "すでにメンバーです。" })
+          return
+        }
+        if (err.code === "FORBIDDEN") {
+          setError("root", { type: "server", message: "メンバーを追加する権限がありません。" })
+          return
+        }
+
+        setError("root", { type: "server", message: "追加に失敗しました。時間をおいて再度お試しください。" })
+      }
+    },
+    [groupId, requireToken, setError, onSuccess]
+  )
+
+  return { submit }
+}

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useAddMemberSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useAddMemberSubmit.ts
@@ -32,8 +32,7 @@ export function useAddMemberSubmit(
           setError("user_id", { type: "server", message: "ユーザーが見つかりません。" })
           return
         }
-        // 409 は ApiErrorCode に定義がないため status で判定
-        if (err.status === 409) {
+        if (err.code === "CONFLICT") {
           setError("user_id", { type: "server", message: "すでにメンバーです。" })
           return
         }

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_schemas/addMemberSchema.ts
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_schemas/addMemberSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export const addMemberSchema = z.object({
+  user_id: z.string().min(1, "ユーザーIDを入力してください"),
+})
+
+export type AddMemberValues = z.infer<typeof addMemberSchema>

--- a/frontend/src/app/(dashboard)/groups/[groupId]/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/page.tsx
@@ -7,6 +7,7 @@ import { GlassCard } from "@/components/ui/GlassCard"
 import { InfoRow } from "@/components/ui/InfoRow"
 import { Badge } from "@/components/ui/Badge"
 import { FeedbackPanel } from "@/components/ui/FeedbackPanel"
+import { AddMemberForm } from "./_components/AddMemberForm"
 
 type Props = {
   params: Promise<{ groupId: string }>
@@ -14,7 +15,7 @@ type Props = {
 
 export default function GroupDetailPage({ params }: Props) {
   const { groupId } = use(params)
-  const { group, members, isLoading, error } = useGroupDetail(groupId)
+  const { group, members, isLoading, error, mutate } = useGroupDetail(groupId)
 
   return (
     <main className="min-h-screen bg-black text-white">
@@ -71,7 +72,10 @@ export default function GroupDetailPage({ params }: Props) {
                   メンバー ({members.length}人)
                 </h2>
               </div>
-              <ul className="mt-2 space-y-3">
+
+              <AddMemberForm groupId={groupId} onSuccess={mutate} />
+
+              <ul className="mt-4 space-y-3">
                 {members.map((member) => (
                   <li
                     key={member.user_id}

--- a/frontend/src/hooks/useGroupDetail.ts
+++ b/frontend/src/hooks/useGroupDetail.ts
@@ -16,7 +16,7 @@ export function useGroupDetail(groupId: string) {
     path
   )
 
-  const { data, error, isLoading } = useSWR<GroupDetailResponse, ApiError>(
+  const { data, error, isLoading, mutate } = useSWR<GroupDetailResponse, ApiError>(
     groupId && /^[1-9A-HJ-NP-Za-km-z]{26}$/.test(groupId) ? path : null,
     () => fetcher(),
     {
@@ -29,5 +29,6 @@ export function useGroupDetail(groupId: string) {
     members: data?.members ?? [],
     isLoading,
     error: error ?? null,
+    mutate,
   }
 }

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,5 +1,5 @@
 import { toApiError } from "@/lib/api/problemDetailsError"
-import type { GroupListResponse } from "@/types/groups"
+import type { GroupListResponse, GroupMemberRole } from "@/types/groups"
 
 
 export type Group = {
@@ -98,3 +98,34 @@ export async function fetchGroups(
   })
 }
 
+
+/**
+ * POST /api/v1/groups/:groupId/members
+ */
+export type AddMemberPayload = {
+  user_id: string
+}
+
+export type AddMemberResponse = {
+  member: {
+    id: string
+    group_id: string
+    user_id: string
+    role: GroupMemberRole
+    active: boolean
+    joined_at: string | null
+  }
+}
+
+export async function addMember(
+  groupId: string,
+  payload: AddMemberPayload,
+  opts: { token?: string; baseUrl?: string } = {}
+) {
+  return requestJson<AddMemberResponse>(`/api/v1/groups/${encodeURIComponent(groupId)}/members`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+    token: opts.token,
+    baseUrl: opts.baseUrl,
+  })
+}

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,5 +1,5 @@
 import { toApiError } from "@/lib/api/problemDetailsError"
-import type { GroupListResponse, GroupMemberRole } from "@/types/groups"
+import type { GroupListResponse } from "@/types/groups"
 
 
 export type Group = {
@@ -106,23 +106,12 @@ export type AddMemberPayload = {
   user_id: string
 }
 
-export type AddMemberResponse = {
-  member: {
-    id: string
-    group_id: string
-    user_id: string
-    role: GroupMemberRole
-    active: boolean
-    joined_at: string | null
-  }
-}
-
 export async function addMember(
   groupId: string,
   payload: AddMemberPayload,
   opts: { token?: string; baseUrl?: string } = {}
-) {
-  return requestJson<AddMemberResponse>(`/api/v1/groups/${encodeURIComponent(groupId)}/members`, {
+): Promise<void> {
+  await requestJson<unknown>(`/api/v1/groups/${encodeURIComponent(groupId)}/members`, {
     method: "POST",
     body: JSON.stringify(payload),
     token: opts.token,

--- a/frontend/src/lib/api/problemDetailsError.ts
+++ b/frontend/src/lib/api/problemDetailsError.ts
@@ -1,6 +1,7 @@
 import type { ProblemDetails } from "@/types/problemDetails"
 
-export type ApiErrorCode = "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "API_ERROR"
+export type ApiErrorCode = "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "API_ERROR"
+
 
 export type ApiError = Error & {
   status?: number
@@ -12,6 +13,7 @@ export function statusToCode(status: number): ApiErrorCode {
   if (status === 401) return "UNAUTHORIZED"
   if (status === 403) return "FORBIDDEN"
   if (status === 404) return "NOT_FOUND"
+  if (status === 409) return "CONFLICT"
   return "API_ERROR"
 }
 


### PR DESCRIPTION
## 概要

グループ詳細画面からメンバーを追加できるUIを実装しました。

## 実装内容

- メンバー追加フォームを実装（モーダル）
- userIdを入力してメンバー追加できるように実装
- 追加成功後にグループ詳細を再取得
- エラー時のメッセージ表示

## 補足（重要）

本来の仕様としては以下を想定していますが、
今回はUI/API接続の確認を優先し、暫定的に userId 入力方式で実装しています。

- 招待URLによる参加
- QRコードによる参加

今後、招待トークンベースの仕様に置き換える前提です。

## スコープ外

- API仕様変更
- 招待URL / QRコード機能の実装

## 確認観点

- userId(public_id)入力でメンバー追加できること
- 追加後にメンバー一覧が更新されること
- エラー時に適切なメッセージが表示されること

## 今後の方針

以下のIssueで置き換え予定：

- 招待URLベースの参加フロー
- QRコードによる参加

その際、本PRのUIはリファクタ or 差し替え予定です。