### PR TITLE
feat: グループ退出API実装（POST /api/v1/groups/:groupId/members/:memberId/leave）#28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,8 @@ yarn-error.log*
 # Articles (local drafts)
 ####################################
 doc/articles/
+
+####################################
+# Claude Code (local settings)
+####################################
+.claude/settings.local.json

--- a/backend/app/controllers/api/v1/groups/members_controller.rb
+++ b/backend/app/controllers/api/v1/groups/members_controller.rb
@@ -3,10 +3,10 @@
 class Api::V1::Groups::MembersController < ApplicationController
   before_action :set_group
   before_action :authorize_member_addition!, only: %i[create]
-  before_action :set_member, only: %i[leave]
-  before_action :authorize_group_member!, only: %i[leave]
-  before_action :authorize_self_only!,    only: %i[leave]
-  before_action :authorize_not_owner!, only: %i[leave]
+  before_action :set_member, only: %i[destroy]
+  before_action :authorize_group_member!, only: %i[destroy]
+  before_action :authorize_self_only!,    only: %i[destroy]
+  before_action :authorize_not_owner!, only: %i[destroy]
 
   def create
     user = User.find_by!(public_id: member_params[:user_id])
@@ -34,9 +34,9 @@ class Api::V1::Groups::MembersController < ApplicationController
     )
   end
 
-  def leave
+  def destroy
     @member.leave!
-    render json: { member: member_response(@member) }, status: :ok
+    head :no_content
   end
 
   private

--- a/backend/app/controllers/api/v1/groups/members_controller.rb
+++ b/backend/app/controllers/api/v1/groups/members_controller.rb
@@ -2,7 +2,10 @@
 
 class Api::V1::Groups::MembersController < ApplicationController
   before_action :set_group
-  before_action :authorize_member_addition!
+  before_action :authorize_member_addition!, only: %i[create]
+  before_action :set_member, only: %i[leave]
+  before_action :authorize_self_leave!, only: %i[leave]
+  before_action :authorize_not_owner!, only: %i[leave]
 
   def create
     user = User.find_by!(public_id: member_params[:user_id])
@@ -30,6 +33,13 @@ class Api::V1::Groups::MembersController < ApplicationController
     )
   end
 
+  def leave
+    return render json: { member: member_response(@member) }, status: :ok unless @member.active?
+
+    @member.leave!
+    render json: { member: member_response(@member) }, status: :ok
+  end
+
   private
 
   def set_group
@@ -38,6 +48,16 @@ class Api::V1::Groups::MembersController < ApplicationController
     render_not_found(
       reason: "group_not_found",
       detail: "Group not found"
+    )
+  end
+
+  def set_member
+    @member = @group.members.find_by(public_id: params[:id])
+    return if @member.present?
+
+    render_not_found(
+      reason: "member_not_found",
+      detail: "Member not found"
     )
   end
 
@@ -50,6 +70,31 @@ class Api::V1::Groups::MembersController < ApplicationController
     render_forbidden(
       reason: "insufficient_role",
       detail: "Only owner can add members"
+    )
+  end
+
+  def authorize_self_leave!
+    return if @member.user_id == current_user.id
+
+    unless @group.members.exists?(user: current_user, active: true)
+      return render_forbidden(
+        reason: "not_group_member",
+        detail: "You are not a member of this group"
+      )
+    end
+
+    render_forbidden(
+      reason: "cannot_leave_other_member",
+      detail: "You can only leave the group as yourself"
+    )
+  end
+
+  def authorize_not_owner!
+    return unless @member.role == Member::ROLE_OWNER
+
+    render_unprocessable_entity(
+      reason: "owner_cannot_leave",
+      detail: "Owner cannot leave the group"
     )
   end
 

--- a/backend/app/controllers/api/v1/groups/members_controller.rb
+++ b/backend/app/controllers/api/v1/groups/members_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::Groups::MembersController < ApplicationController
   before_action :set_group
   before_action :authorize_member_addition!, only: %i[create]
   before_action :set_member, only: %i[leave]
-  before_action :authorize_self_leave!, only: %i[leave]
+  before_action :authorize_group_member!, only: %i[leave]
+  before_action :authorize_self_only!,    only: %i[leave]
   before_action :authorize_not_owner!, only: %i[leave]
 
   def create
@@ -34,8 +35,6 @@ class Api::V1::Groups::MembersController < ApplicationController
   end
 
   def leave
-    return render json: { member: member_response(@member) }, status: :ok unless @member.active?
-
     @member.leave!
     render json: { member: member_response(@member) }, status: :ok
   end
@@ -43,8 +42,9 @@ class Api::V1::Groups::MembersController < ApplicationController
   private
 
   def set_group
-    @group = Group.find_by!(public_id: params[:group_id])
-  rescue ActiveRecord::RecordNotFound
+    @group = Group.find_by(public_id: params[:group_id])
+    return if @group.present?
+
     render_not_found(
       reason: "group_not_found",
       detail: "Group not found"
@@ -73,15 +73,18 @@ class Api::V1::Groups::MembersController < ApplicationController
     )
   end
 
-  def authorize_self_leave!
-    return if @member.user_id == current_user.id
+  def authorize_group_member!
+    # 退出の冪等性を保つため、inactive メンバーによる自身の再退出も許可する
+    return if @group.members.exists?(user: current_user)
 
-    unless @group.members.exists?(user: current_user, active: true)
-      return render_forbidden(
-        reason: "not_group_member",
-        detail: "You are not a member of this group"
-      )
-    end
+    render_forbidden(
+      reason: "not_group_member",
+      detail: "You are not a member of this group"
+    )
+  end
+
+  def authorize_self_only!
+    return if @member.user_id == current_user.id
 
     render_forbidden(
       reason: "cannot_leave_other_member",

--- a/backend/app/controllers/concerns/problem_renderable.rb
+++ b/backend/app/controllers/concerns/problem_renderable.rb
@@ -80,6 +80,18 @@ module ProblemRenderable
     )
   end
 
+  def render_unprocessable_entity(reason:, detail: nil, type: "about:blank", instance: nil, **ext)
+    render_problem(
+      title: "Unprocessable Entity",
+      status: 422,
+      reason: reason,
+      detail: detail,
+      type: type,
+      instance: instance,
+      **ext
+    )
+  end
+
   def render_internal_server_error(reason: "internal_server_error", detail: nil)
     render_problem(
       title: "Internal Server Error",

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -31,6 +31,17 @@ class Member < ApplicationRecord
     self
   end
 
+  def leave!
+    return self unless active?
+
+    update!(
+      active: false,
+      left_at: Time.current
+    )
+
+    self
+  end
+
   private
 
   def ensure_public_id

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,7 +9,11 @@ Rails.application.routes.draw do
       get "me/shared_group_users", to: "me/shared_group_users#index"
 
       resources :groups, only: %i[index create show] do
-        resources :members, only: [:create], module: :groups
+        resources :members, only: [:create], module: :groups do
+          member do
+            post :leave
+          end
+        end
         resource :invite_token, only: [:update], module: :groups
       end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,11 +9,7 @@ Rails.application.routes.draw do
       get "me/shared_group_users", to: "me/shared_group_users#index"
 
       resources :groups, only: %i[index create show] do
-        resources :members, only: [:create], module: :groups do
-          member do
-            post :leave
-          end
-        end
+        resources :members, only: %i[create destroy], module: :groups
         resource :invite_token, only: [:update], module: :groups
       end
 

--- a/backend/spec/requests/api/v1/groups/members/destroy_spec.rb
+++ b/backend/spec/requests/api/v1/groups/members/destroy_spec.rb
@@ -1,12 +1,12 @@
-# backend/spec/requests/api/v1/groups/members/leave_spec.rb
+# backend/spec/requests/api/v1/groups/members/destroy_spec.rb
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request do
-  subject(:leave_request) do
-    post "/api/v1/groups/#{group_id_param}/members/#{member_id_param}/leave",
-         headers: headers
+RSpec.describe "DELETE /api/v1/groups/:group_id/members/:id", type: :request do
+  subject(:destroy_request) do
+    delete "/api/v1/groups/#{group_id_param}/members/#{member_id_param}",
+           headers: headers
   end
 
   let!(:group) { create(:group) }
@@ -43,38 +43,29 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
       let!(:member_id_param) { self_member.public_id }
 
-      it "200 OK を返す" do
-        leave_request
-        expect(response).to have_http_status(:ok)
+      it "204 No Content を返す" do
+        destroy_request
+        expect(response).to have_http_status(:no_content)
       end
 
       it "メンバーが active=false になる" do
-        expect { leave_request }
+        expect { destroy_request }
           .to change { self_member.reload.active }.from(true).to(false)
       end
 
       it "left_at が記録される" do
-        expect { leave_request }
+        expect { destroy_request }
           .to change { self_member.reload.left_at }.from(nil)
       end
 
-      it "退出後のメンバー情報を返す" do
-        leave_request
-
-        body = response.parsed_body
-        expect(body["member"]).to include(
-          "id" => self_member.public_id,
-          "group_id" => group.public_id,
-          "user_id" => member_user.public_id,
-          "role" => "MEMBER",
-          "active" => false
-        )
-        expect(body["member"]["left_at"]).to be_present
+      it "レスポンスボディが空である" do
+        destroy_request
+        expect(response.body).to be_blank
       end
 
-      it "200 の OpenAPI スキーマに一致する" do
-        leave_request
-        assert_response_schema_confirm(200)
+      it "204 の OpenAPI スキーマに一致する" do
+        destroy_request
+        assert_response_schema_confirm(204)
       end
     end
 
@@ -93,22 +84,22 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
       let!(:member_id_param) { self_member.public_id }
 
-      it "200 OK を返す（冪等）" do
-        leave_request
-        expect(response).to have_http_status(:ok)
+      it "204 No Content を返す（冪等）" do
+        destroy_request
+        expect(response).to have_http_status(:no_content)
       end
 
       it "active が変わらない" do
-        expect { leave_request }.not_to change { self_member.reload.active }
+        expect { destroy_request }.not_to change { self_member.reload.active }
       end
 
       it "left_at が変わらない" do
-        expect { leave_request }.not_to change { self_member.reload.left_at }
+        expect { destroy_request }.not_to change { self_member.reload.left_at }
       end
 
-      it "200 の OpenAPI スキーマに一致する" do
-        leave_request
-        assert_response_schema_confirm(200)
+      it "204 の OpenAPI スキーマに一致する" do
+        destroy_request
+        assert_response_schema_confirm(204)
       end
     end
 
@@ -132,21 +123,21 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
 
       it "422 Unprocessable Entity を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "reason に owner_cannot_leave を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("owner_cannot_leave")
       end
 
       it "メンバーの active が変わらない" do
-        expect { leave_request }.not_to change { owner_member.reload.active }
+        expect { destroy_request }.not_to change { owner_member.reload.active }
       end
 
       it "422 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(422)
       end
     end
@@ -175,21 +166,21 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       let!(:member_id_param) { owner_member.public_id }
 
       it "403 Forbidden を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:forbidden)
       end
 
       it "reason に cannot_leave_other_member を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("cannot_leave_other_member")
       end
 
       it "対象メンバーの active が変わらない" do
-        expect { leave_request }.not_to change { owner_member.reload.active }
+        expect { destroy_request }.not_to change { owner_member.reload.active }
       end
 
       it "403 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(403)
       end
     end
@@ -219,21 +210,21 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       let!(:member_id_param) { owner_member.public_id }
 
       it "403 Forbidden を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:forbidden)
       end
 
       it "reason に cannot_leave_other_member を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("cannot_leave_other_member")
       end
 
       it "対象メンバーの active が変わらない" do
-        expect { leave_request }.not_to change { owner_member.reload.active }
+        expect { destroy_request }.not_to change { owner_member.reload.active }
       end
 
       it "403 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(403)
       end
     end
@@ -259,17 +250,17 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
 
       it "403 Forbidden を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:forbidden)
       end
 
       it "reason に not_group_member を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("not_group_member")
       end
 
       it "403 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(403)
       end
     end
@@ -279,17 +270,17 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       let!(:member_id_param) { "mem_dummy" }
 
       it "404 Not Found を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:not_found)
       end
 
       it "reason に group_not_found を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("group_not_found")
       end
 
       it "404 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(404)
       end
     end
@@ -308,17 +299,17 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       let!(:member_id_param) { "mem_not_found" }
 
       it "404 Not Found を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:not_found)
       end
 
       it "reason に member_not_found を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("member_not_found")
       end
 
       it "404 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(404)
       end
     end
@@ -339,22 +330,22 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
 
       it "401 Unauthorized を返す" do
-        leave_request
+        destroy_request
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "reason に missing_token を返す" do
-        leave_request
+        destroy_request
         expect(response.parsed_body["reason"]).to eq("missing_token")
       end
 
       it "Content-Type が application/problem+json になる" do
-        leave_request
+        destroy_request
         expect(response.media_type).to eq("application/problem+json")
       end
 
       it "401 の OpenAPI スキーマに一致する" do
-        leave_request
+        destroy_request
         assert_response_schema_confirm(401)
       end
     end

--- a/backend/spec/requests/api/v1/groups/members/leave_spec.rb
+++ b/backend/spec/requests/api/v1/groups/members/leave_spec.rb
@@ -282,18 +282,8 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
 
   context "認証に失敗しているとき" do
     context "Authorization ヘッダーがないとき" do
-      let!(:member_user) { create(:user, external_uid: "clerk_member_123") }
-      let!(:self_member) do
-        create(
-          :member,
-          group: group,
-          user: member_user,
-          role: "MEMBER",
-          active: true,
-          joined_at: Time.current
-        )
-      end
-      let!(:member_id_param) { self_member.public_id }
+      let!(:group_id_param)  { "grp_unused" }
+      let!(:member_id_param) { "mem_unused" }
       let!(:headers) do
         {
           "Content-Type" => "application/json"

--- a/backend/spec/requests/api/v1/groups/members/leave_spec.rb
+++ b/backend/spec/requests/api/v1/groups/members/leave_spec.rb
@@ -194,6 +194,50 @@ RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request
       end
     end
 
+    context "inactive な自分の member を持つユーザーが他人を退出させようとしたとき" do
+      let!(:owner_member) do
+        create(
+          :member,
+          group: group,
+          user: owner_user,
+          role: "OWNER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: false,
+          joined_at: 2.days.ago,
+          left_at: 1.day.ago
+        )
+      end
+      let!(:member_id_param) { owner_member.public_id }
+
+      it "403 Forbidden を返す" do
+        leave_request
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "reason に cannot_leave_other_member を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("cannot_leave_other_member")
+      end
+
+      it "対象メンバーの active が変わらない" do
+        expect { leave_request }.not_to change { owner_member.reload.active }
+      end
+
+      it "403 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(403)
+      end
+    end
+
     context "実行ユーザーがグループメンバーではないとき" do
       let!(:outsider) { create(:user, external_uid: "clerk_outsider_123") }
       let!(:self_member) do

--- a/backend/spec/requests/api/v1/groups/members/leave_spec.rb
+++ b/backend/spec/requests/api/v1/groups/members/leave_spec.rb
@@ -1,0 +1,328 @@
+# backend/spec/requests/api/v1/groups/members/leave_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/groups/:group_id/members/:id/leave", type: :request do
+  subject(:leave_request) do
+    post "/api/v1/groups/#{group_id_param}/members/#{member_id_param}/leave",
+         headers: headers
+  end
+
+  let!(:group) { create(:group) }
+  let!(:token) { "test-token" }
+  let!(:headers) do
+    {
+      "Authorization" => "Bearer #{token}",
+      "Content-Type" => "application/json"
+    }
+  end
+  let!(:group_id_param)  { group.public_id }
+  let!(:member_id_param) { "mem_dummy" }
+
+  context "認証に成功しているとき" do
+    let!(:owner_user)  { create(:user, external_uid: "clerk_owner_123") }
+    let!(:member_user) { create(:user, external_uid: "clerk_member_123") }
+
+    before do
+      allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+        { "sub" => member_user.external_uid }
+      )
+    end
+
+    context "MEMBER 自身が active のとき" do
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { self_member.public_id }
+
+      it "200 OK を返す" do
+        leave_request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "メンバーが active=false になる" do
+        expect { leave_request }
+          .to change { self_member.reload.active }.from(true).to(false)
+      end
+
+      it "left_at が記録される" do
+        expect { leave_request }
+          .to change { self_member.reload.left_at }.from(nil)
+      end
+
+      it "退出後のメンバー情報を返す" do
+        leave_request
+
+        body = response.parsed_body
+        expect(body["member"]).to include(
+          "id" => self_member.public_id,
+          "group_id" => group.public_id,
+          "user_id" => member_user.public_id,
+          "role" => "MEMBER",
+          "active" => false
+        )
+        expect(body["member"]["left_at"]).to be_present
+      end
+
+      it "200 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(200)
+      end
+    end
+
+    context "すでに inactive なメンバーのとき" do
+      let!(:previous_left_at) { 1.day.ago }
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: false,
+          joined_at: 2.days.ago,
+          left_at: previous_left_at
+        )
+      end
+      let!(:member_id_param) { self_member.public_id }
+
+      it "200 OK を返す（冪等）" do
+        leave_request
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "active が変わらない" do
+        expect { leave_request }.not_to change { self_member.reload.active }
+      end
+
+      it "left_at が変わらない" do
+        expect { leave_request }.not_to change { self_member.reload.left_at }
+      end
+
+      it "200 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(200)
+      end
+    end
+
+    context "OWNER 自身が退出しようとしたとき" do
+      let!(:owner_member) do
+        create(
+          :member,
+          group: group,
+          user: owner_user,
+          role: "OWNER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { owner_member.public_id }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "422 Unprocessable Entity を返す" do
+        leave_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "reason に owner_cannot_leave を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("owner_cannot_leave")
+      end
+
+      it "メンバーの active が変わらない" do
+        expect { leave_request }.not_to change { owner_member.reload.active }
+      end
+
+      it "422 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(422)
+      end
+    end
+
+    context "他人の memberId を退出しようとしたとき" do
+      let!(:owner_member) do
+        create(
+          :member,
+          group: group,
+          user: owner_user,
+          role: "OWNER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { owner_member.public_id }
+
+      it "403 Forbidden を返す" do
+        leave_request
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "reason に cannot_leave_other_member を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("cannot_leave_other_member")
+      end
+
+      it "対象メンバーの active が変わらない" do
+        expect { leave_request }.not_to change { owner_member.reload.active }
+      end
+
+      it "403 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(403)
+      end
+    end
+
+    context "実行ユーザーがグループメンバーではないとき" do
+      let!(:outsider) { create(:user, external_uid: "clerk_outsider_123") }
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { self_member.public_id }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => outsider.external_uid }
+        )
+      end
+
+      it "403 Forbidden を返す" do
+        leave_request
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "reason に not_group_member を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("not_group_member")
+      end
+
+      it "403 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(403)
+      end
+    end
+
+    context "対象グループが存在しないとき" do
+      let!(:group_id_param)  { "grp_not_found" }
+      let!(:member_id_param) { "mem_dummy" }
+
+      it "404 Not Found を返す" do
+        leave_request
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "reason に group_not_found を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("group_not_found")
+      end
+
+      it "404 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(404)
+      end
+    end
+
+    context "対象メンバーが存在しないとき" do
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { "mem_not_found" }
+
+      it "404 Not Found を返す" do
+        leave_request
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "reason に member_not_found を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("member_not_found")
+      end
+
+      it "404 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(404)
+      end
+    end
+  end
+
+  context "認証に失敗しているとき" do
+    context "Authorization ヘッダーがないとき" do
+      let!(:member_user) { create(:user, external_uid: "clerk_member_123") }
+      let!(:self_member) do
+        create(
+          :member,
+          group: group,
+          user: member_user,
+          role: "MEMBER",
+          active: true,
+          joined_at: Time.current
+        )
+      end
+      let!(:member_id_param) { self_member.public_id }
+      let!(:headers) do
+        {
+          "Content-Type" => "application/json"
+        }
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!)
+      end
+
+      it "401 Unauthorized を返す" do
+        leave_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "reason に missing_token を返す" do
+        leave_request
+        expect(response.parsed_body["reason"]).to eq("missing_token")
+      end
+
+      it "Content-Type が application/problem+json になる" do
+        leave_request
+        expect(response.media_type).to eq("application/problem+json")
+      end
+
+      it "401 の OpenAPI スキーマに一致する" do
+        leave_request
+        assert_response_schema_confirm(401)
+      end
+    end
+  end
+end

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -232,22 +232,23 @@ paths:
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
 
-  /api/v1/groups/{groupId}/members/{memberId}/leave:
-    post:
-      operationId: leaveMember
+  /api/v1/groups/{groupId}/members/{memberId}:
+    delete:
+      operationId: removeMember
       tags:
         - Members
-      summary: 退出（active=false, left_at=now）
+      summary: メンバー削除（論理削除：退出 / 将来的にキック）
+      description: >
+        メンバーを論理削除します（active=false, left_at=now）。
+        現状は自分自身のメンバーシップのみ削除可能（=退出）です。
+        OWNER は退出できません（422）。
+        既に inactive のメンバーに対する削除は冪等です（204）。
       parameters:
         - $ref: "#/components/parameters/GroupId"
         - $ref: "#/components/parameters/MemberId"
       responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MemberResponse"
+        "204":
+          description: No Content
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":


### PR DESCRIPTION
## 概要

グループのメンバーが自身でグループから退出できる API を実装しました。`members.active=false` と `left_at` を正しく機能させ、OWNER 退出制限・RFC9457 準拠のエラーハンドリングを揃えました。

closes #28

## 背景

メンバー追加 API・グループ詳細 API は実装済みだったものの、参加後にグループから抜ける手段がありませんでした。`members.active` / `left_at` カラム自体は既に用意されていたため、これらを正しく更新する API が必要でした。

## 変更内容

- **退出 API 実装**: `POST /api/v1/groups/:group_id/members/:id/leave`
- **退出処理ロジックを Model に集約**: `Member#leave!` を新設（既存 `rejoin!` と対称）
- **OWNER 退出制限**: 422 `owner_cannot_leave` で拒否
- **認可フィルタを追加**: `set_member` / `authorize_self_leave!` / `authorize_not_owner!`
- **RFC9457 ヘルパー追加**: `render_unprocessable_entity`（バリデーション以外の 422 用、汎用）
- **既存 `authorize_member_addition!` を `only: :create` に限定**: leave 動作に影響しないよう責務分離
- **Request spec 追加**: 30 example、OpenAPI schema 整合性検証含む

OpenAPI 定義は既存ファイルにスキーマ・operation 含めて完備されていたため、変更不要でした。

## API 仕様

### エンドポイント

```
POST /api/v1/groups/{groupId}/members/{memberId}/leave
```

### 成功レスポンス

| ステータス | 内容 |
|---|---|
| 200 OK | 退出処理後のメンバー情報を返す（`{ member: { ... } }`） |

冪等性：すでに `active=false` の場合も 200 を返し、`left_at` は更新しない。

### レスポンス body（200）

```json
{
  "member": {
    "id": "...",
    "group_id": "...",
    "user_id": "...",
    "role": "MEMBER",
    "active": false,
    "joined_at": "2026-05-13T...",
    "left_at": "2026-05-13T...",
    "created_at": "...",
    "updated_at": "..."
  }
}
```

## エラーハンドリング（RFC9457 / application/problem+json）

| ステータス | reason | 発生条件 |
|---|---|---|
| 401 | `missing_token` / `invalid_token` | 認証失敗 |
| 403 | `not_group_member` | 実行ユーザーが対象グループの active member ではない |
| 403 | `cannot_leave_other_member` | 自分以外のメンバーを退出させようとした |
| 404 | `group_not_found` | groupId が存在しない |
| 404 | `member_not_found` | memberId が存在しない |
| 422 | `owner_cannot_leave` | OWNER が自分を退出させようとした |

すべて `Content-Type: application/problem+json` で返却。

## テスト

### Request spec

`backend/spec/requests/api/v1/groups/members/leave_spec.rb`（新規）

| コンテキスト | example 数 |
|---|---:|
| MEMBER 自身が active で退出 | 5 |
| すでに inactive なメンバーが再度退出（冪等） | 4 |
| OWNER 自身が退出 | 4 |
| 他人の memberId を退出 | 4 |
| 実行ユーザーがグループメンバーではない | 3 |
| 対象グループが存在しない | 3 |
| 対象メンバーが存在しない | 3 |
| Authorization ヘッダーなし | 4 |
| **合計** | **30** |

- すべての status で `assert_response_schema_confirm` による OpenAPI 整合性検証を実施
- 副作用検証は `change` matcher を使用（`from(true).to(false)` / `not_to change`）
- willnet/rspec-style-guide 準拠（`let!` 統一、`subject(:leave_request)` 集約、二重 `describe` 解消）

### 実行結果

```
$ bundle exec rspec spec/requests/api/v1/groups/members/leave_spec.rb
30 examples, 0 failures

$ bundle exec rspec
163 examples, 0 failures
```

## 動作確認

- [x] MEMBER 自身が退出できる
- [x] 退出後 `active=false` になる
- [x] 退出後 `left_at` が記録される
- [x] すでに inactive な状態で再度退出を呼んでも 200（冪等）で `left_at` が変わらない
- [x] OWNER 自身は退出できない（422 `owner_cannot_leave`）
- [x] 他人のメンバーは退出させられない（403 `cannot_leave_other_member`）
- [x] グループ未所属ユーザーは 403 `not_group_member`
- [x] 存在しない groupId は 404 `group_not_found`
- [x] 存在しない memberId は 404 `member_not_found`
- [x] 未認証は 401 `missing_token` + `application/problem+json`
- [x] OpenAPI schema check 全 PASS

## 影響範囲

以下の既存機能に影響がないことを Request spec 全件 PASS で確認済み：

- **グループ一覧**（`GET /api/v1/groups`）: active member のグループのみ返す挙動を維持
- **グループ詳細**（`GET /api/v1/groups/:id`）: active members のみ返す挙動を維持
- **メンバー追加**（`POST /api/v1/groups/:id/members`）: `authorize_member_addition!` への `only: :create` 追加に伴い leave への誤適用は無し
- **招待参加 / 再参加**（`Member#join_or_rejoin!` / `rejoin!`）: `leave!` を対称に追加したのみで既存ロジック未変更
- **招待トークン再生成**: 影響なし

DB スキーマ変更・マイグレーションなし。OpenAPI 変更なし。
