### PR TITLE
feat: グループ詳細から退出できるUIを実装 #29

### DIFF
--- a/backend/app/controllers/api/v1/groups_controller.rb
+++ b/backend/app/controllers/api/v1/groups_controller.rb
@@ -100,6 +100,7 @@ class Api::V1::GroupsController < ApplicationController
   def active_members_json(group)
     active_members(group).map do |member|
       {
+        public_id: member.public_id,
         user_id: member.user.public_id,
         name: member.user.name,
         role: member.role

--- a/backend/spec/requests/api/v1/groups_spec.rb
+++ b/backend/spec/requests/api/v1/groups_spec.rb
@@ -478,6 +478,13 @@ RSpec.describe "Groups API", type: :request do
             returned_user_ids = members.map { |member| member.fetch("user_id") }
             expect(returned_user_ids).to include(user.public_id, owner_user.public_id)
             expect(returned_user_ids).not_to include(inactive_user.public_id)
+
+            self_member = Member.find_by!(group: group, user: user)
+            owner_member = Member.find_by!(group: group, user: owner_user)
+            expect(members.map { |m| m.fetch("public_id") }).to contain_exactly(
+              self_member.public_id,
+              owner_member.public_id
+            )
           end
         end
 

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_components/LeaveGroupSection.tsx
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_components/LeaveGroupSection.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useState, useId, useEffect, useRef } from "react"
+import { GlassCard } from "@/components/ui/GlassCard"
+import type { GroupMember } from "@/types/groups"
+import { useLeaveGroupSubmit } from "../_hooks/useLeaveGroupSubmit"
+
+type Props = {
+  groupId: string
+  groupName: string
+  myMember: GroupMember | null
+}
+
+export function LeaveGroupSection({ groupId, groupName, myMember }: Props) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  if (!myMember) return null
+
+  const isOwner = myMember.role === "OWNER"
+
+  return (
+    <GlassCard className="mt-8 border-rose-500/20 bg-rose-500/[0.04]">
+      <h2 className="text-sm font-semibold text-rose-200">危険ゾーン</h2>
+      <p className="mt-3 text-sm text-white/70">
+        グループから退出すると、このグループのデータにアクセスできなくなります。
+        過去の支払い記録は他のメンバーには引き続き表示されます。
+      </p>
+
+      {isOwner ? (
+        <p className="mt-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-white/60">
+          オーナーはグループから退出できません。
+          退出するには、先に他のメンバーにオーナー権限を譲渡してください（今後実装予定）。
+        </p>
+      ) : (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setIsDialogOpen(true)}
+            className="inline-flex items-center justify-center rounded-full border border-rose-400/30 bg-rose-500/10 px-5 py-2.5 text-sm font-semibold text-rose-100 transition hover:bg-rose-500/20 focus:outline-none focus:ring-2 focus:ring-rose-300/40"
+          >
+            このグループから退出する
+          </button>
+        </div>
+      )}
+
+      {isDialogOpen && (
+        <LeaveGroupConfirmDialog
+          groupId={groupId}
+          groupName={groupName}
+          memberId={myMember.public_id}
+          onClose={() => setIsDialogOpen(false)}
+        />
+      )}
+    </GlassCard>
+  )
+}
+
+type DialogProps = {
+  groupId: string
+  groupName: string
+  memberId: string
+  onClose: () => void
+}
+
+function LeaveGroupConfirmDialog({ groupId, groupName, memberId, onClose }: DialogProps) {
+  const titleId = useId()
+  const descId = useId()
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+  const dialogContainerRef = useRef<HTMLDivElement>(null)
+
+  const { submit, isSubmitting, errorMessage } = useLeaveGroupSubmit(groupId, memberId)
+
+  // ダイアログ表示中は背景をスクロール不可に
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [])
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isSubmitting) {
+        onClose()
+        return
+      }
+      // フォーカストラップ：Tab / Shift+Tab でダイアログ内をループ
+      if (e.key === "Tab") {
+        const container = dialogContainerRef.current
+        if (!container) return
+        const focusables = container.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        const active = document.activeElement as HTMLElement | null
+
+        if (e.shiftKey && active === first) {
+          e.preventDefault()
+          last.focus()
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [isSubmitting, onClose])
+
+  const handleConfirm = async () => {
+    const ok = await submit()
+    if (ok) {
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      ref={dialogContainerRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isSubmitting) onClose()
+      }}
+    >
+      <div className="w-full max-w-md rounded-3xl border border-white/10 bg-neutral-900 p-6 shadow-2xl">
+        <h3 id={titleId} className="text-lg font-bold text-white">
+          グループから退出しますか？
+        </h3>
+        <p id={descId} className="mt-3 text-sm text-white/70">
+          「{groupName}」から退出します。退出後はこのグループのデータにアクセスできなくなります。
+          再参加するには招待リンクが必要です。
+        </p>
+
+        {errorMessage && (
+          <p
+            className="mt-3 rounded-2xl border border-rose-400/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-100"
+            role="alert"
+          >
+            {errorMessage}
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-full bg-rose-500 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-rose-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? "退出中..." : "退出する"}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useLeaveGroupSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useLeaveGroupSubmit.ts
@@ -1,0 +1,79 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useRouter } from "next/navigation"
+import { removeMember } from "@/lib/api/groups"
+import type { ApiError } from "@/lib/api/problemDetailsError"
+import { useRequireAuth } from "@/hooks/useRequireAuth"
+
+type State = {
+  isSubmitting: boolean
+  errorMessage: string | null
+}
+
+function resolveErrorMessage(err: ApiError): string {
+  if (err.status === 401 || err.code === "UNAUTHORIZED") {
+    return "ログインが必要です。"
+  }
+
+  const reason = err.problem?.reason
+
+  if (err.status === 403) {
+    if (reason === "cannot_leave_other_member") return "自分以外を退出させることはできません。"
+    if (reason === "not_group_member") return "このグループのメンバーではありません。"
+    return "退出する権限がありません。"
+  }
+
+  if (err.status === 404) {
+    if (reason === "group_not_found") return "グループが見つかりません。"
+    if (reason === "member_not_found") return "メンバーが見つかりません。"
+    return "グループまたはメンバーが見つかりません。"
+  }
+
+  if (err.status === 422 && reason === "owner_cannot_leave") {
+    return "オーナーはグループから退出できません。"
+  }
+
+  return "退出に失敗しました。時間をおいて再度お試しください。"
+}
+
+export function useLeaveGroupSubmit(groupId: string, memberId: string | null) {
+  const router = useRouter()
+  const { requireToken } = useRequireAuth()
+  const [state, setState] = useState<State>({
+    isSubmitting: false,
+    errorMessage: null,
+  })
+
+  const submit = useCallback(async (): Promise<boolean> => {
+    if (!memberId) {
+      setState({ isSubmitting: false, errorMessage: "退出対象のメンバーが特定できません。" })
+      return false
+    }
+
+    setState({ isSubmitting: true, errorMessage: null })
+
+    const token = await requireToken(`/groups/${groupId}`)
+    if (!token) {
+      setState({ isSubmitting: false, errorMessage: "ログインが必要です。" })
+      return false
+    }
+
+    try {
+      await removeMember(groupId, memberId, { token })
+      router.push("/groups")
+      router.refresh()
+      return true
+    } catch (e) {
+      const err = e as ApiError
+      setState({ isSubmitting: false, errorMessage: resolveErrorMessage(err) })
+      return false
+    }
+  }, [groupId, memberId, requireToken, router])
+
+  return {
+    submit,
+    isSubmitting: state.isSubmitting,
+    errorMessage: state.errorMessage,
+  }
+}

--- a/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useLeaveGroupSubmit.ts
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/_hooks/useLeaveGroupSubmit.ts
@@ -11,30 +11,31 @@ type State = {
   errorMessage: string | null
 }
 
+const REASON_MESSAGES: Record<string, string> = {
+  cannot_leave_other_member: "自分以外を退出させることはできません。",
+  not_group_member: "このグループのメンバーではありません。",
+  group_not_found: "グループが見つかりません。",
+  member_not_found: "メンバーが見つかりません。",
+  owner_cannot_leave: "オーナーはグループから退出できません。",
+}
+
+const STATUS_FALLBACKS: Record<number, string> = {
+  401: "ログインが必要です。",
+  403: "退出する権限がありません。",
+  404: "グループまたはメンバーが見つかりません。",
+}
+
 function resolveErrorMessage(err: ApiError): string {
   if (err.status === 401 || err.code === "UNAUTHORIZED") {
-    return "ログインが必要です。"
+    return STATUS_FALLBACKS[401]
   }
 
   const reason = err.problem?.reason
-
-  if (err.status === 403) {
-    if (reason === "cannot_leave_other_member") return "自分以外を退出させることはできません。"
-    if (reason === "not_group_member") return "このグループのメンバーではありません。"
-    return "退出する権限がありません。"
-  }
-
-  if (err.status === 404) {
-    if (reason === "group_not_found") return "グループが見つかりません。"
-    if (reason === "member_not_found") return "メンバーが見つかりません。"
-    return "グループまたはメンバーが見つかりません。"
-  }
-
-  if (err.status === 422 && reason === "owner_cannot_leave") {
-    return "オーナーはグループから退出できません。"
-  }
-
-  return "退出に失敗しました。時間をおいて再度お試しください。"
+  return (
+    (reason && REASON_MESSAGES[reason]) ??
+    (err.status !== undefined ? STATUS_FALLBACKS[err.status] : undefined) ??
+    "退出に失敗しました。時間をおいて再度お試しください。"
+  )
 }
 
 export function useLeaveGroupSubmit(groupId: string, memberId: string | null) {

--- a/frontend/src/app/(dashboard)/groups/[groupId]/page.tsx
+++ b/frontend/src/app/(dashboard)/groups/[groupId]/page.tsx
@@ -3,11 +3,13 @@
 import { use } from "react"
 import Link from "next/link"
 import { useGroupDetail } from "@/hooks/useGroupDetail"
+import { useMe } from "@/hooks/useMe"
 import { GlassCard } from "@/components/ui/GlassCard"
 import { InfoRow } from "@/components/ui/InfoRow"
 import { Badge } from "@/components/ui/Badge"
 import { FeedbackPanel } from "@/components/ui/FeedbackPanel"
 import { AddMemberForm } from "./_components/AddMemberForm"
+import { LeaveGroupSection } from "./_components/LeaveGroupSection"
 
 type Props = {
   params: Promise<{ groupId: string }>
@@ -16,16 +18,15 @@ type Props = {
 export default function GroupDetailPage({ params }: Props) {
   const { groupId } = use(params)
   const { group, members, isLoading, error, mutate } = useGroupDetail(groupId)
+  const { me } = useMe()
+
+  const myMember = me ? (members.find((m) => m.user_id === me.public_id) ?? null) : null
 
   return (
     <main className="min-h-screen bg-black text-white">
       <div className="relative mx-auto max-w-4xl px-6 py-10">
-
         <div className="mb-6">
-          <Link
-            href="/groups"
-            className="text-sm text-white/50 hover:text-white/80 transition"
-          >
+          <Link href="/groups" className="text-sm text-white/50 hover:text-white/80 transition">
             ← グループ一覧に戻る
           </Link>
         </div>
@@ -57,11 +58,15 @@ export default function GroupDetailPage({ params }: Props) {
                 <InfoRow label="通貨" value={group.currency} />
                 <InfoRow
                   label="作成日"
-                  value={group.created_at ? new Date(group.created_at).toLocaleDateString("ja-JP") : "—"}
+                  value={
+                    group.created_at ? new Date(group.created_at).toLocaleDateString("ja-JP") : "—"
+                  }
                 />
                 <InfoRow
                   label="更新日"
-                  value={group.updated_at ? new Date(group.updated_at).toLocaleDateString("ja-JP") : "—"}
+                  value={
+                    group.updated_at ? new Date(group.updated_at).toLocaleDateString("ja-JP") : "—"
+                  }
                 />
               </div>
             </GlassCard>
@@ -89,9 +94,10 @@ export default function GroupDetailPage({ params }: Props) {
                 ))}
               </ul>
             </GlassCard>
+
+            <LeaveGroupSection groupId={groupId} groupName={group.name} myMember={myMember} />
           </>
         )}
-
       </div>
     </main>
   )

--- a/frontend/src/hooks/useMe.ts
+++ b/frontend/src/hooks/useMe.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import useSWR from "swr"
+import type { MeResponse } from "@/types/user"
+import { useAuthenticatedFetch } from "@/lib/api/authenticatedFetch"
+import { createSWRAuthenticatedFetcher } from "@/lib/api/createSWRAuthenticatedFetcher"
+import type { ApiError } from "@/lib/api/problemDetailsError"
+
+// NOTE: 認証切り替え時にキャッシュが残る既知の課題あり → Issue #48
+export function useMe() {
+  const authenticatedFetch = useAuthenticatedFetch()
+  const path = "/api/v1/me"
+
+  const fetcher = createSWRAuthenticatedFetcher<MeResponse>(authenticatedFetch, path)
+
+  const { data, error, isLoading, mutate } = useSWR<MeResponse, ApiError>(path, () => fetcher(), {
+    revalidateOnFocus: false,
+  })
+
+  return {
+    me: data?.user ?? null,
+    isLoading,
+    error: error ?? null,
+    mutate,
+  }
+}

--- a/frontend/src/lib/api/groups.ts
+++ b/frontend/src/lib/api/groups.ts
@@ -1,7 +1,6 @@
 import { toApiError } from "@/lib/api/problemDetailsError"
 import type { GroupListResponse } from "@/types/groups"
 
-
 export type Group = {
   public_id: string
   name: string
@@ -70,7 +69,7 @@ export type CreateGroupPayload = {
 
 export async function createGroup(
   payload: CreateGroupPayload,
-  opts: { token?: string; baseUrl?: string } = {}
+  opts: { token?: string; baseUrl?: string } = {},
 ) {
   return requestJson<CreateGroupResponse>("/api/v1/groups", {
     method: "POST",
@@ -85,7 +84,7 @@ export async function createGroup(
  */
 export async function fetchGroups(
   params: { page?: number } = {},
-  opts: { token?: string; baseUrl?: string } = {}
+  opts: { token?: string; baseUrl?: string } = {},
 ): Promise<GroupListResponse> {
   const search = new URLSearchParams()
   if (params.page) search.set("page", String(params.page))
@@ -98,7 +97,6 @@ export async function fetchGroups(
   })
 }
 
-
 /**
  * POST /api/v1/groups/:groupId/members
  */
@@ -109,7 +107,7 @@ export type AddMemberPayload = {
 export async function addMember(
   groupId: string,
   payload: AddMemberPayload,
-  opts: { token?: string; baseUrl?: string } = {}
+  opts: { token?: string; baseUrl?: string } = {},
 ): Promise<void> {
   await requestJson<unknown>(`/api/v1/groups/${encodeURIComponent(groupId)}/members`, {
     method: "POST",
@@ -117,4 +115,35 @@ export async function addMember(
     token: opts.token,
     baseUrl: opts.baseUrl,
   })
+}
+
+/**
+ * DELETE /api/v1/groups/:groupId/members/:memberId
+ *
+ * - 204 No Content を期待。レスポンスボディは無し
+ * - 失敗時は ApiError を throw（401/403/404/422）
+ */
+export async function removeMember(
+  groupId: string,
+  memberId: string,
+  opts: { token?: string; baseUrl?: string } = {},
+): Promise<void> {
+  const path = `/api/v1/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(memberId)}`
+  const headers = new Headers()
+  headers.set("Accept", "application/json")
+  if (opts.token) {
+    headers.set("Authorization", `Bearer ${opts.token}`)
+  }
+
+  const res = await fetch(buildUrl(path, opts.baseUrl), {
+    method: "DELETE",
+    headers,
+    cache: "no-store",
+  })
+
+  if (res.status === 204) return
+  if (!res.ok) {
+    throw await toApiError(res)
+  }
+  throw new Error(`Unexpected status: ${res.status}`)
 }

--- a/frontend/src/types/groups.ts
+++ b/frontend/src/types/groups.ts
@@ -21,6 +21,8 @@ export type GroupListResponse = {
 export type GroupMemberRole = "OWNER" | "MEMBER"
 
 export type GroupMember = {
+  /** Member.public_id（DELETE /groups/:groupId/members/:memberId で使う） */
+  public_id: string
   user_id: string
   name: string | null
   role: GroupMemberRole

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,17 @@
+export type ThemeMode = "SYSTEM" | "LIGHT" | "DARK"
+
+export type Me = {
+  id: number
+  public_id: string
+  external_uid: string
+  name: string | null
+  email: string | null
+  notify_email: boolean | null
+  theme_mode: ThemeMode | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export type MeResponse = {
+  user: Me
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -911,12 +911,22 @@ components:
           items:
             type: object
             required:
+              - public_id
               - user_id
+              - name
               - role
             properties:
+              public_id:
+                type: string
+                description: Member の公開ID（退出 API 等で DELETE 対象に使う）
+                example: 01H00000000000000000000099
               user_id:
                 type: string
                 example: 01H00000000000000000000015
+              name:
+                type: string
+                nullable: true
+                description: User.name（未設定時は null）
               role:
                 $ref: "#/components/schemas/MemberRole"
 


### PR DESCRIPTION
## 概要

グループ詳細ページから自身が退出できる UI を実装しました。退出後はグループ一覧へリダイレクトし、危険操作のため確認ダイアログを必ず挟む構成です。

closes #29

## 背景

ISSUE #28 で `DELETE /api/v1/groups/{groupId}/members/{memberId}` のバックエンド実装が完了していましたが、フロントから呼び出すには次の前提が不足していました：

- `GET /api/v1/groups/{id}` のメンバー JSON に **`Member.public_id` が含まれていない** → DELETE の URL に渡せない
- 「自分がどのメンバーか」を判定する仕組みがフロントに無い

そのため本 PR では UI 実装に加えて、最小限の API 拡張も含めています。

## 変更内容

### Backend（API 契約拡張）
- `GET /api/v1/groups/{id}` のメンバー JSON に `public_id` を追加
- OpenAPI: `GroupDetailResponse.members` の schema に `public_id` / `name` を required で追加
- Request spec: `Member.public_id` の対応関係を `contain_exactly` で検証

### Frontend
- `useMe` hook 新設：`GET /api/v1/me` を SWR で取得し全画面で共有
- `types/user.ts` 新設：`Me` / `MeResponse` / `ThemeMode` 型を定義
- `types/groups.ts`: `GroupMember` に `public_id` を追加
- `removeMember` API クライアント関数を追加（DELETE + 204 対応）
- `useLeaveGroupSubmit` hook 新設：退出送信ロジック + エラーメッセージ解決
- `LeaveGroupSection` コンポーネント新設：「危険ゾーン」セクション + 確認モーダル内包
- グループ詳細ページに `useMe` で自分のメンバー特定処理と `LeaveGroupSection` を統合

## UI 仕様

### 「危険ゾーン」セクション
- メンバーカードの下に独立配置
- 一般メンバー：「このグループから退出する」ボタンを表示
- OWNER：ボタン非表示 +「オーナーはグループから退出できません。退出するには先に他のメンバーにオーナー権限を譲渡してください（今後実装予定）」と案内

<img width="1005" height="762" alt="スクリーンショット 2026-05-19 7 39 15" src="https://github.com/user-attachments/assets/9bbae7b8-33cf-4e09-bd7d-d30f1da58761" />


### 確認モーダル
- 背景クリック / Cancel ボタン / Escape キーで閉じる
- `role="dialog"` `aria-modal` `aria-labelledby` `aria-describedby` でアクセシビリティ対応
- 初期フォーカスは Cancel ボタン
- **body スクロールロック**: 表示中は背景がスクロールできない
- **フォーカストラップ**: Tab / Shift+Tab でモーダル内をループ
- 二重送信防止：送信中は両ボタン disabled

<img width="971" height="785" alt="スクリーンショット 2026-05-19 7 39 27" src="https://github.com/user-attachments/assets/bdb4b509-de8d-4717-8f3e-500f8e2903ab" />


### エラーハンドリング
`resolveErrorMessage(err)` で status + reason から日本語メッセージに解決：

| status | reason | メッセージ |
|---|---|---|
| 401 | - | ログインが必要です。 |
| 403 | cannot_leave_other_member | 自分以外を退出させることはできません。 |
| 403 | not_group_member | このグループのメンバーではありません。 |
| 403 | (その他) | 退出する権限がありません。 |
| 404 | group_not_found | グループが見つかりません。 |
| 404 | member_not_found | メンバーが見つかりません。 |
| 422 | owner_cannot_leave | オーナーはグループから退出できません。 |
| - | - | 退出に失敗しました。時間をおいて再度お試しください。 |

## 設計判断

### API 拡張範囲：B 案（既存 DELETE に揃える）を採用
`POST .../leave` や `/members/me` のエイリアス新設ではなく、`DELETE /members/:id` を呼ぶための **`Member.public_id` 露出のみ** を採用：
- 直前ブランチ (#28) で `POST .../leave` → `DELETE /members/:id` の REST 化を済ませた流れと整合
- 将来「OWNER による kick 機能」を同じ DELETE エンドポイントで対応可能
- 他リソース（Group, User, Member）と同じく `public_id` を露出するスタイルに統一

### 確認モーダル：カスタム実装（共通基盤は YAGNI）
プロジェクトにモーダル基盤がないため `LeaveGroupConfirmDialog` を `LeaveGroupSection` 内に局所実装。汎用 `Modal.tsx` は 2 個目のモーダルが出た時点で抽出する方針。

### OWNER ガード:クライアント + サーバ多段防御
- UI でボタン非表示（即座にフィードバック）
- サーバの 422 owner_cannot_leave は保険として動作

## 動作確認

- [x] 一般メンバーで退出ボタンが表示される
- [x] ボタン押下で確認ダイアログ表示
- [x] Escape / Cancel / 背景クリックで閉じる
- [x] 「退出する」で 204 受信後 \`/groups\` にリダイレクト・該当グループが一覧から消える
- [x] OWNER アカウントでボタン非表示・案内文表示
- [x] body スクロールロックが効く
- [x] フォーカストラップで背景の input にフォーカスが移らない
- [x] 二重送信できない（isSubmitting で disabled）
- [x] 既存のメンバー追加 UI が壊れていない
- [x] \`bundle exec rspec\`：163 examples / 0 failures
- [x] \`npx tsc --noEmit\`：エラーなし
- [x] \`npm run lint\`：エラーなし
