### PR TITLE
fix(frontend): 認証ユーザー切替時のSWRキャッシュ汚染を解消 #48

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.2",
+        "swr": "^2.3.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.2",
+    "swr": "^2.3.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { ClerkProvider } from "@clerk/nextjs"
+import { AppProviders } from "@/app/providers/AppProviders"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -31,8 +32,7 @@ export default function RootLayout({
           headerSubtitle: "text-white/60",
           socialButtonsBlockButton:
             "bg-white/5 border border-white/10 text-white hover:bg-white/10",
-          formButtonPrimary:
-            "bg-emerald-500 text-neutral-950 hover:bg-emerald-400",
+          formButtonPrimary: "bg-emerald-500 text-neutral-950 hover:bg-emerald-400",
           formFieldInput:
             "bg-white/5 border-white/10 text-white placeholder:text-white/40 focus:ring-emerald-400/40",
           footerActionLink: "text-emerald-300 hover:text-emerald-200",
@@ -41,24 +41,26 @@ export default function RootLayout({
     >
       <html lang="ja" suppressHydrationWarning>
         <body className="min-h-screen text-white antialiased">
-          {/* グローバル背景（全ページ共通） */}
-          <div className="relative min-h-screen bg-neutral-950">
-            {/* light blobs */}
-            <div className="pointer-events-none absolute inset-0">
-              <div className="absolute -top-44 left-1/2 h-140 w-140 -translate-x-1/2 rounded-full bg-emerald-500/22 blur-3xl" />
-              <div className="absolute -bottom-60 -right-35 h-140 w-140 rounded-full bg-teal-400/18 blur-3xl" />
-              <div className="absolute top-24 -left-40 h-105 w-105 rounded-full bg-lime-300/10 blur-3xl" />
+          <AppProviders>
+            {/* グローバル背景（全ページ共通） */}
+            <div className="relative min-h-screen bg-neutral-950">
+              {/* light blobs */}
+              <div className="pointer-events-none absolute inset-0">
+                <div className="absolute -top-44 left-1/2 h-140 w-140 -translate-x-1/2 rounded-full bg-emerald-500/22 blur-3xl" />
+                <div className="absolute -bottom-60 -right-35 h-140 w-140 rounded-full bg-teal-400/18 blur-3xl" />
+                <div className="absolute top-24 -left-40 h-105 w-105 rounded-full bg-lime-300/10 blur-3xl" />
 
-              {/* subtle grid */}
-              <div className="absolute inset-0 opacity-[0.08] bg-[linear-gradient(to_right,rgba(255,255,255,0.25)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.25)_1px,transparent_1px)] bg-size-[48px_48px]" />
+                {/* subtle grid */}
+                <div className="absolute inset-0 opacity-[0.08] bg-[linear-gradient(to_right,rgba(255,255,255,0.25)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.25)_1px,transparent_1px)] bg-size-[48px_48px]" />
 
-              {/* depth */}
-              <div className="absolute inset-0 bg-linear-to-b from-black/0 via-black/10 to-black/35" />
+                {/* depth */}
+                <div className="absolute inset-0 bg-linear-to-b from-black/0 via-black/10 to-black/35" />
+              </div>
+
+              {/* content */}
+              <div className="relative min-h-screen">{children}</div>
             </div>
-
-            {/* content */}
-            <div className="relative min-h-screen">{children}</div>
-          </div>
+          </AppProviders>
         </body>
       </html>
     </ClerkProvider>

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useAuth } from "@clerk/nextjs"
+import { SWRConfig, useSWRConfig } from "swr"
+
+/**
+ * 認証ユーザー切替時に SWR キャッシュを全廃棄する内部コンポーネント。
+ *
+ * Issue #48: A でログイン中に取得したキャッシュが、B でログインしたときに
+ * 一瞬表示されるのを防ぐ。サーバ側は JWT で常に正しいユーザーのデータを返すが、
+ * クライアントの in-memory cache が古い値を保持しているため。
+ *
+ * mutate(() => true, undefined, { revalidate: false }) で全キーを無効化。
+ * 再フェッチは各フックの次回マウント時に走る。
+ */
+function AuthCacheInvalidator() {
+  const { userId, isLoaded } = useAuth()
+  const { mutate } = useSWRConfig()
+  const prevUserIdRef = useRef<string | null | undefined>(undefined)
+
+  useEffect(() => {
+    if (!isLoaded) return
+
+    const prev = prevUserIdRef.current
+    const next = userId ?? null
+
+    if (prev === undefined) {
+      prevUserIdRef.current = next
+      return
+    }
+
+    if (prev !== next) {
+      if (process.env.NODE_ENV === "development") {
+        console.info("[AuthCacheInvalidator] cleared cache", { prev, next })
+      }
+      mutate(() => true, undefined, { revalidate: false })
+      prevUserIdRef.current = next
+    }
+  }, [isLoaded, userId, mutate])
+
+  return null
+}
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig value={{}}>
+      <AuthCacheInvalidator />
+      {children}
+    </SWRConfig>
+  )
+}

--- a/frontend/src/hooks/useMe.ts
+++ b/frontend/src/hooks/useMe.ts
@@ -6,7 +6,6 @@ import { useAuthenticatedFetch } from "@/lib/api/authenticatedFetch"
 import { createSWRAuthenticatedFetcher } from "@/lib/api/createSWRAuthenticatedFetcher"
 import type { ApiError } from "@/lib/api/problemDetailsError"
 
-// NOTE: 認証切り替え時にキャッシュが残る既知の課題あり → Issue #48
 export function useMe() {
   const authenticatedFetch = useAuthenticatedFetch()
   const path = "/api/v1/me"


### PR DESCRIPTION
## 概要

\`useMe\` / \`useGroups\` / \`useGroupDetail\` などすべての SWR フックで、認証ユーザー切替時に前のユーザーのキャッシュが残り、新しいユーザーのページに一瞬古いデータが表示される問題を解消しました。

closes #48

## 背景

サーバ側は毎リクエストで JWT を検証し、常に正しいユーザーのデータを返します。問題は **クライアントの in-memory SWR cache** が古い値を保持し続けることです：

1. ユーザー A でログイン → \`/api/v1/me\` 等が SWR にキャッシュされる
2. ログアウト → ユーザー B でログイン
3. 同じページにアクセスすると、SWR cache hit で **A のデータが一瞬表示** され、その後 fetcher が走って B のデータに置き換わる

特に \`useGroups\` は \`keepPreviousData: true\` のため、汚染が最も目立つ形で残ります。

## 設計判断：3 案から「中央集約」を採用

| 案 | アプローチ | 評価 |
|---|---|---|
| A | 各フックで \`userId\` 変更を監視 → \`mutate(undefined)\` | ❌ フック追加のたび漏れリスク |
| B | SWR key に \`userId\` を含める | ❌ 既存全フック書き換え必要 |
| **C** | **\`SWRConfig\` + Clerk \`userId\` 監視で全キャッシュクリア** | **✅ 中央 1 箇所で完結** |

採用理由（このアプリ特性）:
- フロントテスト基盤が未整備 → **漏れの概念自体を消す設計**が安全
- フックが今後増える見込み（expense, settlement 等）→ 拡張に強い
- 既存 3 フックを **一切触らない** → 回帰リスク最小

## 変更内容

- \`AppProviders.tsx\` を新設し \`SWRConfig\` と \`AuthCacheInvalidator\` を内包
- \`layout.tsx\` で \`<ClerkProvider>\` 内に \`<AppProviders>\` を配置
- \`useAuth().userId\` の変化を \`useRef\` で観測し、変化時に \`mutate(() => true, undefined, { revalidate: false })\` で全キャッシュ廃棄
- \`revalidate: false\` で不要な再フェッチを抑制（各フックが次回マウント時に自前で取得）
- 開発時のみ \`console.info\` で動作確認できる
- \`useMe.ts\` の Issue #48 NOTE コメントを削除（本 fix で解消）
- \`swr\` を \`package.json\` の \`dependencies\` に明示（直接 import するため）

## 動作仕様

| シナリオ | 挙動 |
|---|---|
| 初回ログイン（マウント時） | \`prevUserIdRef === undefined\` のため何もしない |
| 同一ユーザーのページ間遷移 | \`userId\` 不変のため何もしない |
| A → ログアウト | \`null\` への変化を検知 → 全キャッシュ廃棄 |
| ログアウト → B でログイン | \`null → B\` の変化を検知 → 全キャッシュ廃棄 |
| A → B 直接切替（レアケース）| \`A → B\` の変化を検知 → 全キャッシュ廃棄 |

## 動作確認

- [x] TypeScript: \`tsc --noEmit\` エラーなし
- [x] ESLint: エラーなし
- [x] Prettier（PR スコープファイル）: 全 PASS
- [x] 同タブでサインアウト時に \`[AuthCacheInvalidator] cleared cache\` が dev console に出力される

## やっていないこと

- 複数タブ間でのキャッシュ同期（BroadcastChannel 等）→ 別 Issue 推奨
- SWR key に userId を含める設計変更 → 過剰実装のため不採用
- \`revalidateOnFocus\` 等の SWR デフォルト統一 → 別 PR 推奨
- E2E テスト追加 → フロントテスト基盤未整備のため別 Issue
