### PR TITLE
feat: 支払い登録 API を実装 (POST /api/v1/groups/:group_id/expenses) #51

### DIFF
--- a/backend/app/controllers/api/v1/groups/expenses_controller.rb
+++ b/backend/app/controllers/api/v1/groups/expenses_controller.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+class Api::V1::Groups::ExpensesController < ApplicationController
+  before_action :set_group
+  before_action :authorize_active_member!
+
+  def create
+    payer = User.find_by(public_id: expense_params[:paid_by_id])
+    return render_invalid_payer if payer.nil?
+
+    splits_payload, invalid_user_id = build_splits_payload(expense_params[:splits])
+    return render_invalid_split_member(invalid_user_id) if invalid_user_id
+
+    expense = @group.add_expense!(
+      payer: payer,
+      creator: current_user,
+      amount_cents: expense_params[:amount_cents],
+      paid_on: expense_params[:paid_on],
+      split_type: expense_params[:split_type],
+      category: expense_params[:category],
+      note: expense_params[:note],
+      splits_payload: splits_payload
+    )
+
+    render json: expense_response(expense), status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render_record_invalid(e.record)
+  end
+
+  private
+
+  def set_group
+    @group = Group.find_by(public_id: params[:group_id])
+    return if @group.present?
+
+    render_not_found(reason: "group_not_found", detail: "Group not found")
+  end
+
+  def authorize_active_member!
+    return if @group.members.exists?(user: current_user, active: true)
+
+    render_forbidden(
+      reason: "not_group_member",
+      detail: "You are not a member of this group"
+    )
+  end
+
+  def expense_params
+    params.permit(
+      :paid_by_id,
+      :created_by_id,
+      :amount_cents,
+      :paid_on,
+      :category,
+      :note,
+      :split_type,
+      splits: %i[user_id share_cents share_percent]
+    )
+  end
+
+  # splits_payload を user オブジェクト解決済みの配列に変換する。
+  # 解決できない user_id が混ざっていた場合は [nil, invalid_user_id] を返す。
+  def build_splits_payload(splits_param)
+    splits = Array(splits_param).map(&:to_h)
+    return [[], nil] if splits.empty?
+
+    public_ids = splits.map { |s| s["user_id"] || s[:user_id] }
+    users_by_public_id = User.where(public_id: public_ids).index_by(&:public_id)
+
+    payload = []
+    splits.each do |s|
+      pid = s["user_id"] || s[:user_id]
+      user = users_by_public_id[pid]
+      return [nil, pid] if user.nil?
+
+      payload << {
+        user: user,
+        share_cents: s["share_cents"] || s[:share_cents],
+        share_percent: s["share_percent"] || s[:share_percent]
+      }
+    end
+
+    [payload, nil]
+  end
+
+  def render_invalid_payer
+    render_unprocessable_entity(
+      reason: "invalid_payer",
+      detail: "paid_by_id must reference an active group member"
+    )
+  end
+
+  def render_invalid_split_member(user_id)
+    render_unprocessable_entity(
+      reason: "invalid_split_member",
+      detail: "splits contains a user_id that does not exist: #{user_id}"
+    )
+  end
+
+  # Group#add_expense! 内で active member 違反等が起きると Expense.errors にキーが追加され
+  # ActiveRecord::RecordInvalid として raise される。errors の key に応じて reason を分岐する。
+  def render_record_invalid(record)
+    return render_invalid_payer    if record.errors[:paid_by].any?
+    return render_invalid_creator  if record.errors[:created_by].any?
+    return render_invalid_splits   if record.errors[:splits].any? && record.errors.details[:splits].any? { |d| d[:error] == :not_group_member }
+
+    render_validation_error(record)
+  end
+
+  def render_invalid_creator
+    render_unprocessable_entity(
+      reason: "invalid_creator",
+      detail: "created_by must be an active group member"
+    )
+  end
+
+  def render_invalid_splits
+    render_unprocessable_entity(
+      reason: "invalid_split_member",
+      detail: "splits contains a user that is not an active group member"
+    )
+  end
+
+  def expense_response(expense)
+    {
+      expense: expense_json(expense),
+      splits: expense.splits.map { |s| split_json(s) },
+      attachments: []
+    }
+  end
+
+  def expense_json(expense)
+    {
+      id: expense.public_id,
+      group_id: expense.group.public_id,
+      paid_by_id: expense.paid_by.public_id,
+      created_by_id: expense.created_by.public_id,
+      amount_cents: expense.amount_cents,
+      paid_on: expense.paid_on.iso8601,
+      category: expense.category,
+      note: expense.note,
+      split_type: expense.split_type,
+      deleted_at: expense.deleted_at&.iso8601,
+      created_at: expense.created_at&.iso8601,
+      updated_at: expense.updated_at&.iso8601
+    }
+  end
+
+  def split_json(split)
+    {
+      id: split.id.to_s,
+      expense_id: split.expense.public_id,
+      user_id: split.user.public_id,
+      share_cents: split.share_cents,
+      share_percent: split.share_percent,
+      created_at: split.created_at&.iso8601,
+      updated_at: split.updated_at&.iso8601
+    }
+  end
+end

--- a/backend/app/models/expense.rb
+++ b/backend/app/models/expense.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Expense < ApplicationRecord
+  SPLIT_TYPES = %w[EQUAL_ALL EQUAL_SELECTED AMOUNT PERCENT].freeze
+
+  belongs_to :group, inverse_of: :expenses
+  belongs_to :paid_by, class_name: "User"
+  belongs_to :created_by, class_name: "User"
+
+  has_many :splits, inverse_of: :expense, dependent: :destroy
+
+  before_validation :ensure_public_id, on: :create
+
+  validates :public_id, presence: true, uniqueness: true, length: { is: 26 }
+  validates :amount_cents, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :paid_on, presence: true
+  validates :split_type, presence: true, inclusion: { in: SPLIT_TYPES }
+  validate  :splits_sum_matches_amount
+
+  scope :not_deleted, -> { where(deleted_at: nil) }
+
+  private
+
+  def ensure_public_id
+    return if public_id.present?
+
+    self.public_id = loop do
+      candidate = SecureRandom.base58(26)
+      break candidate unless self.class.exists?(public_id: candidate)
+    end
+  end
+
+  def splits_sum_matches_amount
+    return if splits.blank?
+    return if splits.sum(&:share_cents) == amount_cents
+
+    errors.add(:splits, :sum_mismatch)
+  end
+end

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -5,6 +5,7 @@ class Group < ApplicationRecord
 
   has_many :members, inverse_of: :group, dependent: :destroy
   has_many :users, through: :members
+  has_many :expenses, inverse_of: :group
 
   before_validation :ensure_public_id, on: :create
   before_validation :ensure_invite_token, on: :create
@@ -30,6 +31,38 @@ class Group < ApplicationRecord
     end
   end
 
+  # 支払いを追加する。
+  # - 全 user（payer / creator / splits の user）が active member であることを検証
+  # - expense と splits を atomic に作成
+  # - エラーは ActiveRecord::RecordInvalid として raise（controller でハンドリング）
+  def add_expense!(payer:, creator:, amount_cents:, paid_on:, split_type:, splits_payload:, category: nil, note: nil)
+    ActiveRecord::Base.transaction do
+      active_user_ids = members.where(active: true).pluck(:user_id).to_set
+
+      raise_invalid_member(:paid_by, payer)     unless active_user_ids.include?(payer.id)
+      raise_invalid_member(:created_by, creator) unless active_user_ids.include?(creator.id)
+
+      splits_payload.each do |s|
+        raise_invalid_member(:splits, s[:user]) unless active_user_ids.include?(s[:user].id)
+      end
+
+      expense = expenses.create!(
+        paid_by: payer,
+        created_by: creator,
+        amount_cents: amount_cents,
+        paid_on: paid_on,
+        split_type: split_type,
+        category: category,
+        note: note,
+        splits: splits_payload.map { |s|
+          Split.new(user: s[:user], share_cents: s[:share_cents], share_percent: s[:share_percent])
+        }
+      )
+
+      expense
+    end
+  end
+
   def regenerate_invite_token!
     update!(
       invite_token: generate_unique_invite_token,
@@ -42,6 +75,12 @@ class Group < ApplicationRecord
   end
 
   private
+
+  def raise_invalid_member(field, user)
+    expense = Expense.new
+    expense.errors.add(field, :not_group_member, user_id: user&.public_id)
+    raise ActiveRecord::RecordInvalid, expense
+  end
 
   def ensure_public_id
     return if public_id.present?

--- a/backend/app/models/split.rb
+++ b/backend/app/models/split.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Split < ApplicationRecord
+  belongs_to :expense, inverse_of: :splits
+  belongs_to :user
+
+  validates :share_cents, presence: true,
+                          numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :user_id, uniqueness: { scope: :expense_id }
+  validates :share_percent,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+            allow_nil: true
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       resources :groups, only: %i[index create show] do
         resources :members, only: %i[create destroy], module: :groups
         resource :invite_token, only: [:update], module: :groups
+        resources :expenses, only: %i[create], module: :groups
       end
 
       resources :invites, param: :invite_token, only: [:show]

--- a/backend/db/migrate/20260610070806_create_expenses.rb
+++ b/backend/db/migrate/20260610070806_create_expenses.rb
@@ -1,0 +1,32 @@
+class CreateExpenses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :expenses, id: :bigint do |t|
+      t.string  :public_id,       null: false, limit: 26
+      t.bigint  :group_id,        null: false
+      t.bigint  :paid_by_id,      null: false
+      t.bigint  :created_by_id,   null: false
+      t.integer :amount_cents,    null: false
+      t.date    :paid_on,         null: false
+      t.string  :category
+      t.text    :note
+      t.string  :split_type,      null: false
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+
+    add_index :expenses, :public_id, unique: true
+    add_index :expenses, %i[group_id paid_on]
+    add_index :expenses, %i[group_id deleted_at]
+    add_index :expenses, :paid_by_id
+
+    add_foreign_key :expenses, :groups, column: :group_id
+    add_foreign_key :expenses, :users,  column: :paid_by_id
+    add_foreign_key :expenses, :users,  column: :created_by_id
+
+    add_check_constraint :expenses,
+                         "split_type IN ('EQUAL_ALL','EQUAL_SELECTED','AMOUNT','PERCENT')",
+                         name: "chk_expenses_split_type"
+    add_check_constraint :expenses, "amount_cents > 0", name: "chk_expenses_amount_positive"
+  end
+end

--- a/backend/db/migrate/20260610070807_create_splits.rb
+++ b/backend/db/migrate/20260610070807_create_splits.rb
@@ -1,0 +1,20 @@
+class CreateSplits < ActiveRecord::Migration[8.1]
+  def change
+    create_table :splits, id: :bigint do |t|
+      t.bigint  :expense_id,    null: false
+      t.bigint  :user_id,       null: false
+      t.integer :share_cents,   null: false
+      t.integer :share_percent
+
+      t.timestamps
+    end
+
+    add_index :splits, %i[expense_id user_id], unique: true
+    add_index :splits, :expense_id
+
+    add_foreign_key :splits, :expenses, column: :expense_id
+    add_foreign_key :splits, :users,    column: :user_id
+
+    add_check_constraint :splits, "share_cents >= 0", name: "chk_splits_share_cents_non_negative"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_15_065548) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_070807) do
+  create_table "expenses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.string "category"
+    t.datetime "created_at", null: false
+    t.bigint "created_by_id", null: false
+    t.datetime "deleted_at"
+    t.bigint "group_id", null: false
+    t.text "note"
+    t.bigint "paid_by_id", null: false
+    t.date "paid_on", null: false
+    t.string "public_id", limit: 26, null: false
+    t.string "split_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "fk_rails_f7e2e7081b"
+    t.index ["group_id", "deleted_at"], name: "index_expenses_on_group_id_and_deleted_at"
+    t.index ["group_id", "paid_on"], name: "index_expenses_on_group_id_and_paid_on"
+    t.index ["paid_by_id"], name: "index_expenses_on_paid_by_id"
+    t.index ["public_id"], name: "index_expenses_on_public_id", unique: true
+    t.check_constraint "`amount_cents` > 0", name: "chk_expenses_amount_positive"
+    t.check_constraint "`split_type` in (_utf8mb4'EQUAL_ALL',_utf8mb4'EQUAL_SELECTED',_utf8mb4'AMOUNT',_utf8mb4'PERCENT')", name: "chk_expenses_split_type"
+  end
+
   create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "currency", default: "JPY", null: false
@@ -40,6 +62,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_065548) do
     t.check_constraint "`role` in (_utf8mb4'OWNER',_utf8mb4'MEMBER')", name: "chk_members_role"
   end
 
+  create_table "splits", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "expense_id", null: false
+    t.integer "share_cents", null: false
+    t.integer "share_percent"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["expense_id", "user_id"], name: "index_splits_on_expense_id_and_user_id", unique: true
+    t.index ["expense_id"], name: "index_splits_on_expense_id"
+    t.index ["user_id"], name: "fk_rails_d13926f60f"
+    t.check_constraint "`share_cents` >= 0", name: "chk_splits_share_cents_non_negative"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
@@ -54,6 +89,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_065548) do
     t.check_constraint "`theme_mode` in (_utf8mb4'SYSTEM',_utf8mb4'LIGHT',_utf8mb4'DARK')", name: "chk_users_theme_mode"
   end
 
+  add_foreign_key "expenses", "groups"
+  add_foreign_key "expenses", "users", column: "created_by_id"
+  add_foreign_key "expenses", "users", column: "paid_by_id"
   add_foreign_key "members", "groups"
   add_foreign_key "members", "users"
+  add_foreign_key "splits", "expenses"
+  add_foreign_key "splits", "users"
 end

--- a/backend/spec/factories/expenses.rb
+++ b/backend/spec/factories/expenses.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :expense do
+    association :group
+    association :paid_by, factory: :user
+    association :created_by, factory: :user
+
+    public_id { SecureRandom.base58(26) }
+    amount_cents { 1000 }
+    paid_on { Date.current }
+    split_type { "EQUAL_ALL" }
+    category { nil }
+    note { nil }
+  end
+end

--- a/backend/spec/factories/splits.rb
+++ b/backend/spec/factories/splits.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :split do
+    association :expense
+    association :user
+
+    share_cents { 1000 }
+    share_percent { nil }
+  end
+end

--- a/backend/spec/models/expense_spec.rb
+++ b/backend/spec/models/expense_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Expense, type: :model do
+  describe "バリデーション" do
+    let!(:group)   { create(:group) }
+    let!(:user_a)  { create(:user) }
+    let!(:user_b)  { create(:user) }
+
+    describe "正常系" do
+      context "必須属性が揃い、splits の合計が amount_cents と一致するとき" do
+        subject(:expense) do
+          build(:expense, group: group, paid_by: user_a, created_by: user_a).tap do |e|
+            e.amount_cents = 1000
+            e.splits = [
+              Split.new(user: user_a, share_cents: 500),
+              Split.new(user: user_b, share_cents: 500)
+            ]
+          end
+        end
+
+        it "有効であること" do
+          expect(expense).to be_valid
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "amount_cents が 0 以下のとき" do
+        subject(:expense) do
+          build(:expense, group: group, paid_by: user_a, created_by: user_a, amount_cents: 0)
+        end
+
+        it "無効であること" do
+          expect(expense).to be_invalid
+          expect(expense.errors[:amount_cents]).to be_present
+        end
+      end
+
+      context "split_type が enum 外のとき" do
+        subject(:expense) do
+          build(:expense, group: group, paid_by: user_a, created_by: user_a, split_type: "INVALID")
+        end
+
+        it "無効であること" do
+          expect(expense).to be_invalid
+          expect(expense.errors[:split_type]).to be_present
+        end
+      end
+
+      context "splits の合計が amount_cents と一致しないとき" do
+        subject(:expense) do
+          build(:expense, group: group, paid_by: user_a, created_by: user_a).tap do |e|
+            e.amount_cents = 1000
+            e.splits = [
+              Split.new(user: user_a, share_cents: 400),
+              Split.new(user: user_b, share_cents: 500)
+            ]
+          end
+        end
+
+        it "無効であること" do
+          expect(expense).to be_invalid
+          expect(expense.errors[:splits]).to be_present
+        end
+      end
+    end
+  end
+
+  describe "公開ID自動採番" do
+    let!(:group)  { create(:group) }
+    let!(:user)   { create(:user) }
+
+    context "public_id を指定せず保存するとき" do
+      subject(:expense) do
+        Expense.new(
+          group: group, paid_by: user, created_by: user,
+          amount_cents: 100, paid_on: Date.current, split_type: "EQUAL_ALL",
+          splits: [Split.new(user: user, share_cents: 100)]
+        )
+      end
+
+      it "26文字の public_id が自動採番されること" do
+        expect { expense.save! }.to change { expense.public_id }.from(nil)
+        expect(expense.public_id.length).to eq(26)
+      end
+    end
+  end
+end

--- a/backend/spec/models/group_spec.rb
+++ b/backend/spec/models/group_spec.rb
@@ -273,4 +273,109 @@ RSpec.describe Group, type: :model do
       end
     end
   end
+
+  describe "#add_expense!" do
+    let!(:group)      { create(:group) }
+    let!(:owner)      { create(:user) }
+    let!(:other)      { create(:user) }
+    let!(:outsider)   { create(:user) }
+
+    before do
+      create(:member, group: group, user: owner, role: "OWNER", active: true, joined_at: Time.current)
+      create(:member, group: group, user: other, role: "MEMBER", active: true, joined_at: Time.current)
+    end
+
+    context "全 user が active member のとき" do
+      it "expense と splits を作成すること" do
+        expect do
+          group.add_expense!(
+            payer: owner,
+            creator: owner,
+            amount_cents: 1000,
+            paid_on: Date.current,
+            split_type: "EQUAL_ALL",
+            splits_payload: [
+              { user: owner, share_cents: 500, share_percent: nil },
+              { user: other, share_cents: 500, share_percent: nil }
+            ]
+          )
+        end.to change { Expense.count }.by(1).and change { Split.count }.by(2)
+      end
+
+      it "作成した expense を返すこと" do
+        expense = group.add_expense!(
+          payer: owner,
+          creator: owner,
+          amount_cents: 1000,
+          paid_on: Date.current,
+          split_type: "EQUAL_ALL",
+          splits_payload: [
+            { user: owner, share_cents: 500, share_percent: nil },
+            { user: other, share_cents: 500, share_percent: nil }
+          ]
+        )
+
+        expect(expense).to be_persisted
+        expect(expense.public_id.length).to eq(26)
+        expect(expense.splits.size).to eq(2)
+      end
+    end
+
+    context "payer が active member ではないとき" do
+      it "RecordInvalid を raise し、expense は作成されないこと" do
+        expect do
+          expect do
+            group.add_expense!(
+              payer: outsider,
+              creator: owner,
+              amount_cents: 1000,
+              paid_on: Date.current,
+              split_type: "EQUAL_ALL",
+              splits_payload: [{ user: owner, share_cents: 1000, share_percent: nil }]
+            )
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end.not_to change { Expense.count }
+      end
+    end
+
+    context "splits に active member 以外のユーザーが含まれるとき" do
+      it "RecordInvalid を raise し、expense は作成されないこと" do
+        expect do
+          expect do
+            group.add_expense!(
+              payer: owner,
+              creator: owner,
+              amount_cents: 1000,
+              paid_on: Date.current,
+              split_type: "EQUAL_ALL",
+              splits_payload: [
+                { user: owner, share_cents: 500, share_percent: nil },
+                { user: outsider, share_cents: 500, share_percent: nil }
+              ]
+            )
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end.not_to change { Expense.count }
+      end
+    end
+
+    context "splits の合計が amount_cents と一致しないとき" do
+      it "RecordInvalid を raise し、expense は作成されないこと" do
+        expect do
+          expect do
+            group.add_expense!(
+              payer: owner,
+              creator: owner,
+              amount_cents: 1000,
+              paid_on: Date.current,
+              split_type: "EQUAL_ALL",
+              splits_payload: [
+                { user: owner, share_cents: 400, share_percent: nil },
+                { user: other, share_cents: 500, share_percent: nil }
+              ]
+            )
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end.not_to change { Expense.count }
+      end
+    end
+  end
 end

--- a/backend/spec/models/split_spec.rb
+++ b/backend/spec/models/split_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Split, type: :model do
+  describe "バリデーション" do
+    let!(:group)   { create(:group) }
+    let!(:user)    { create(:user) }
+    let!(:expense) do
+      create(
+        :expense,
+        group: group,
+        paid_by: user,
+        created_by: user,
+        amount_cents: 1000,
+        splits: [Split.new(user: user, share_cents: 1000)]
+      )
+    end
+
+    describe "異常系" do
+      context "share_cents が負のとき" do
+        subject(:split) { build(:split, expense: expense, user: user, share_cents: -1) }
+
+        it "無効であること" do
+          expect(split).to be_invalid
+          expect(split.errors[:share_cents]).to be_present
+        end
+      end
+
+      context "同一 expense 内で user_id が重複するとき" do
+        let!(:other_user) { create(:user) }
+
+        before do
+          # expense は既に user の split を 1 件持っている
+          create(:split, expense: expense, user: other_user, share_cents: 0)
+        end
+
+        subject(:split) { build(:split, expense: expense, user: user, share_cents: 0) }
+
+        it "無効であること" do
+          expect(split).to be_invalid
+          expect(split.errors[:user_id]).to be_present
+        end
+      end
+
+      context "share_percent が範囲外（>100）のとき" do
+        subject(:split) { build(:split, expense: expense, user: user, share_percent: 101) }
+
+        it "無効であること" do
+          expect(split).to be_invalid
+          expect(split.errors[:share_percent]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/groups/expenses/create_spec.rb
+++ b/backend/spec/requests/api/v1/groups/expenses/create_spec.rb
@@ -1,0 +1,310 @@
+# backend/spec/requests/api/v1/groups/expenses/create_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/groups/:group_id/expenses", type: :request do
+  subject(:create_request) do
+    post "/api/v1/groups/#{group_id_param}/expenses",
+         params: body.to_json,
+         headers: headers
+  end
+
+  let!(:group)        { create(:group) }
+  let!(:owner_user)   { create(:user, external_uid: "clerk_owner_123") }
+  let!(:member_user)  { create(:user, external_uid: "clerk_member_123") }
+  let!(:token)        { "test-token" }
+  let!(:headers) do
+    {
+      "Authorization" => "Bearer #{token}",
+      "Content-Type" => "application/json"
+    }
+  end
+  let!(:group_id_param) { group.public_id }
+
+  let!(:owner_member) do
+    create(:member, group: group, user: owner_user, role: "OWNER", active: true, joined_at: Time.current)
+  end
+  let!(:self_member) do
+    create(:member, group: group, user: member_user, role: "MEMBER", active: true, joined_at: Time.current)
+  end
+
+  let!(:body) do
+    {
+      paid_by_id: owner_user.public_id,
+      created_by_id: owner_user.public_id,
+      amount_cents: 1000,
+      paid_on: "2026-06-10",
+      split_type: "EQUAL_ALL",
+      splits: [
+        { user_id: owner_user.public_id, share_cents: 500 },
+        { user_id: member_user.public_id, share_cents: 500 }
+      ]
+    }
+  end
+
+  context "認証に成功しているとき" do
+    context "実行ユーザーが active member で、正常なリクエストを送ったとき" do
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "201 Created を返す" do
+        create_request
+        expect(response).to have_http_status(:created)
+      end
+
+      it "Expense が 1 件作成される" do
+        expect { create_request }.to change { Expense.count }.by(1)
+      end
+
+      it "Split が splits.size 件作成される" do
+        expect { create_request }.to change { Split.count }.by(2)
+      end
+
+      it "レスポンスに expense / splits / attachments が含まれる" do
+        create_request
+
+        body = response.parsed_body
+        expect(body).to include("expense", "splits", "attachments")
+        expect(body["expense"]).to include(
+          "group_id" => group.public_id,
+          "paid_by_id" => owner_user.public_id,
+          "created_by_id" => owner_user.public_id,
+          "amount_cents" => 1000,
+          "paid_on" => "2026-06-10",
+          "split_type" => "EQUAL_ALL"
+        )
+        expect(body["splits"].size).to eq(2)
+        expect(body["attachments"]).to eq([])
+      end
+
+      it "201 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(201)
+      end
+    end
+
+    context "実行ユーザーが代理で他メンバーを payer に指定したとき" do
+      let!(:body) do
+        {
+          paid_by_id: member_user.public_id,
+          created_by_id: owner_user.public_id,
+          amount_cents: 1000,
+          paid_on: "2026-06-10",
+          split_type: "EQUAL_ALL",
+          splits: [
+            { user_id: owner_user.public_id, share_cents: 500 },
+            { user_id: member_user.public_id, share_cents: 500 }
+          ]
+        }
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "201 を返す（代理入力が許容される）" do
+        create_request
+        expect(response).to have_http_status(:created)
+      end
+
+      it "created_by は実行ユーザーで上書きされる" do
+        create_request
+        expect(response.parsed_body["expense"]["created_by_id"]).to eq(owner_user.public_id)
+      end
+
+      it "201 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(201)
+      end
+    end
+
+    context "splits の合計が amount_cents と一致しないとき" do
+      let!(:body) do
+        {
+          paid_by_id: owner_user.public_id,
+          created_by_id: owner_user.public_id,
+          amount_cents: 1000,
+          paid_on: "2026-06-10",
+          split_type: "EQUAL_ALL",
+          splits: [
+            { user_id: owner_user.public_id, share_cents: 400 },
+            { user_id: member_user.public_id, share_cents: 500 }
+          ]
+        }
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "422 を返す" do
+        create_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "Expense は作成されない" do
+        expect { create_request }.not_to change { Expense.count }
+      end
+
+      it "422 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(422)
+      end
+    end
+
+    context "paid_by_id に存在しない user_id を指定したとき" do
+      let!(:body) do
+        {
+          paid_by_id: "usr_not_found",
+          created_by_id: owner_user.public_id,
+          amount_cents: 1000,
+          paid_on: "2026-06-10",
+          split_type: "EQUAL_ALL",
+          splits: [
+            { user_id: owner_user.public_id, share_cents: 1000 }
+          ]
+        }
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "422 を返す" do
+        create_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "reason に invalid_payer を返す" do
+        create_request
+        expect(response.parsed_body["reason"]).to eq("invalid_payer")
+      end
+
+      it "422 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(422)
+      end
+    end
+
+    context "splits にグループ外ユーザーが含まれるとき" do
+      let!(:outsider) { create(:user) }
+      let!(:body) do
+        {
+          paid_by_id: owner_user.public_id,
+          created_by_id: owner_user.public_id,
+          amount_cents: 1000,
+          paid_on: "2026-06-10",
+          split_type: "EQUAL_ALL",
+          splits: [
+            { user_id: owner_user.public_id, share_cents: 500 },
+            { user_id: outsider.public_id, share_cents: 500 }
+          ]
+        }
+      end
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "422 を返す" do
+        create_request
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "reason に invalid_split_member を返す" do
+        create_request
+        expect(response.parsed_body["reason"]).to eq("invalid_split_member")
+      end
+
+      it "Expense は作成されない" do
+        expect { create_request }.not_to change { Expense.count }
+      end
+    end
+
+    context "実行ユーザーがグループメンバーではないとき" do
+      let!(:outsider) { create(:user, external_uid: "clerk_outsider_123") }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => outsider.external_uid }
+        )
+      end
+
+      it "403 を返す" do
+        create_request
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "reason に not_group_member を返す" do
+        create_request
+        expect(response.parsed_body["reason"]).to eq("not_group_member")
+      end
+
+      it "403 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(403)
+      end
+    end
+
+    context "対象グループが存在しないとき" do
+      let!(:group_id_param) { "grp_not_found" }
+
+      before do
+        allow(Clerk::JwtVerifier).to receive(:verify!).with(token).and_return(
+          { "sub" => owner_user.external_uid }
+        )
+      end
+
+      it "404 を返す" do
+        create_request
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "reason に group_not_found を返す" do
+        create_request
+        expect(response.parsed_body["reason"]).to eq("group_not_found")
+      end
+
+      it "404 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(404)
+      end
+    end
+  end
+
+  context "認証に失敗しているとき" do
+    context "Authorization ヘッダーがないとき" do
+      let!(:group_id_param) { "grp_unused" }
+      let!(:headers) do
+        { "Content-Type" => "application/json" }
+      end
+
+      it "401 を返す" do
+        create_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "reason に missing_token を返す" do
+        create_request
+        expect(response.parsed_body["reason"]).to eq("missing_token")
+      end
+
+      it "401 の OpenAPI スキーマに一致する" do
+        create_request
+        assert_response_schema_confirm(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

グループメンバーが支払い情報を登録できる API を実装しました。OpenAPI に既に詳細定義されていた \`createExpense\` operation を実装で満たします。

closes #51

## 背景

OpenAPI には \`Expense\` / \`Split\` / \`ExpenseCreateRequest\` / \`ExpenseResponse\` / \`createExpense\` 等が既に定義されていましたが、Rails 側の実装は未着手でした。\`splits\` も OpenAPI が必須化していたため、本 PR で同時実装しています。

## 変更内容

### Migration（commit \`c6f0ccf\`）
- \`expenses\` テーブル: \`public_id\` / \`group_id\` / \`paid_by_id\` / \`created_by_id\` / \`amount_cents\` / \`paid_on\` / \`category\` / \`note\` / \`split_type\` / \`deleted_at\`
  - 外部キー: groups, users (paid_by_id, created_by_id)
  - CHECK 制約: \`split_type IN ('EQUAL_ALL','EQUAL_SELECTED','AMOUNT','PERCENT')\`, \`amount_cents > 0\`
- \`splits\` テーブル: \`expense_id\` / \`user_id\` / \`share_cents\` / \`share_percent\`
  - \`(expense_id, user_id)\` UNIQUE
  - CHECK 制約: \`share_cents >= 0\`

### Model + Controller + Routes（commit \`4f871a1\`）
- \`Expense\` モデル: \`public_id\` 自動採番、splits 合計 == amount_cents バリデーション
- \`Split\` モデル: share_cents 非負、share_percent 範囲、scope unique
- \`Group#add_expense!\` にドメインロジックを集約
  - 全 user（payer / creator / splits）が active member であることを検証
  - expense + splits を atomic に作成（transaction）
  - 失敗時は \`ActiveRecord::RecordInvalid\` raise
- \`Api::V1::Groups::ExpensesController#create\`
  - 認可: active member のみ作成可（403 \`not_group_member\`）
  - 代理入力許容: paid_by は self 以外でも OK（要件 §3「立替者指定」）
  - \`created_by\` はサーバー側で \`current_user\` に強制上書き（不正防止）
  - 422 reason: \`invalid_payer\` / \`invalid_creator\` / \`invalid_split_member\` / \`splits_sum_mismatch\` / \`validation_error\`
- routes に \`resources :expenses, only: %i[create], module: :groups\` 追加

### Test + Factory（commit \`d450d8a\`）
- factory: \`expenses.rb\` / \`splits.rb\`
- model spec: \`expense_spec\` / \`split_spec\` / \`group_spec\` の \`#add_expense!\` context
- request spec: \`spec/requests/api/v1/groups/expenses/create_spec.rb\`
  - 全 status で \`assert_response_schema_confirm\` により OpenAPI 整合性検証

## API 仕様

### Endpoint
\`POST /api/v1/groups/{groupId}/expenses\`

### Request Body
\`\`\`json
{
  \"paid_by_id\": \"<user public_id>\",
  \"created_by_id\": \"<user public_id>\",
  \"amount_cents\": 1000,
  \"paid_on\": \"2026-06-10\",
  \"category\": null,
  \"note\": null,
  \"split_type\": \"EQUAL_ALL\",
  \"splits\": [
    { \"user_id\": \"<user public_id>\", \"share_cents\": 500 },
    { \"user_id\": \"<user public_id>\", \"share_cents\": 500 }
  ]
}
\`\`\`

### Success Response (201)
\`{ expense, splits, attachments }\` 形式（\`attachments\` は作成直後は空配列）

### Error Responses (RFC9457)
| Status | Reason | 発生条件 |
|---|---|---|
| 401 | \`missing_token\` | 認証なし |
| 403 | \`not_group_member\` | 実行ユーザーが active member でない |
| 404 | \`group_not_found\` | groupId が存在しない |
| 422 | \`invalid_payer\` | paid_by_id のユーザーが存在しない or active member でない |
| 422 | \`invalid_creator\` | created_by が active member でない |
| 422 | \`invalid_split_member\` | splits の user_id がグループの active member でない |
| 422 | \`splits_sum_mismatch\` | splits 合計が amount_cents と一致しない |
| 422 | \`validation_error\` | その他のモデルバリデーションエラー |

## 設計判断（事前合意済み）

| 論点 | 採用方針 |
|---|---|
| splits 同時実装 | ✅ する（OpenAPI 必須化のため） |
| paid_by ≠ self | ✅ 許容（代理入力前提） |
| created_by 強制上書き | ✅ サーバー側で current_user に固定（不正防止） |
| splits の user は active member のみ | ✅ active のみ |
| Group has_many :expenses の dependent | 省略（グループ削除 API がないため実害なし） |
| ID 統一 | \`public_id\`（26 文字 base58） |

## 動作確認

- [x] \`bundle exec rspec\` 全 207 examples / 0 failures
- [x] \`bundle exec rails routes -g expenses\` で正しいルート生成確認
- [x] Request spec の全 status で \`assert_response_schema_confirm\` PASS（OpenAPI 整合性担保）
- [x] migration 適用後 schema.rb の差分確認
- [x] 既存テスト（groups / members / invites 等）への影響なし

## やっていないこと（別 Issue）

- 一覧 API（GET /expenses）→ #52
- 詳細 / 編集 / 削除 API → 別 Issue
- フロント実装 → #53
- 精算計算ロジック → 別 Issue
- \`Attachment\` 関連 → 別 Issue
